### PR TITLE
fix(handler): add missing created timestamp to chat response and stream chunks

### DIFF
--- a/internal/app/handler.go
+++ b/internal/app/handler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"time"
 )
 
 const maxChatRequestBytes = 50 * 1024 * 1024
@@ -88,6 +89,7 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 			}
 			chunk := ChatStreamChunk{
 				ID:     genStreamID(),
+				Created: time.Now().Unix(),
 				Object: "chat.completion.chunk",
 				Model:  model,
 				Choices: []StreamChoice{{
@@ -106,6 +108,7 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 			}
 			chunk := ChatStreamChunk{
 				ID:     genStreamID(),
+				Created: time.Now().Unix(),
 				Object: "chat.completion.chunk",
 				Model:  model,
 				Choices: []StreamChoice{{
@@ -126,6 +129,7 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 			argsJSON, _ := json.Marshal(input)
 			chunk := ChatStreamChunk{
 				ID:     genStreamID(),
+				Created: time.Now().Unix(),
 				Object: "chat.completion.chunk",
 				Model:  model,
 				Choices: []StreamChoice{{
@@ -175,6 +179,7 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 
 			chunk := ChatStreamChunk{
 				ID:     genStreamID(),
+				Created: time.Now().Unix(),
 				Object: "chat.completion.chunk",
 				Model:  model,
 				Choices: []StreamChoice{{
@@ -324,6 +329,7 @@ func handleNonStream(w http.ResponseWriter, resp *http.Response, model string, u
 
 	res := ChatResponse{
 		ID:     genStreamID(),
+		Created: time.Now().Unix(),
 		Object: "chat.completion",
 		Model:  model,
 		Choices: []Choice{{

--- a/internal/app/handler_test.go
+++ b/internal/app/handler_test.go
@@ -149,6 +149,9 @@ func TestHandleNonStreamNormalizesFinishReason(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v body = %s", err, rec.Body.String())
 	}
+	if got.Created == 0 {
+		t.Fatalf("created = %d, want non-zero", got.Created)
+	}
 	if got.Choices[0].FinishReason != "length" {
 		t.Fatalf("finish_reason = %q, want length", got.Choices[0].FinishReason)
 	}
@@ -239,6 +242,12 @@ func TestHandleStreamEmitsDoneOnceWithFinishStep(t *testing.T) {
 	}
 	if !strings.Contains(body, `"finish_reason":"stop"`) {
 		t.Fatalf("body missing finish chunk: %s", body)
+	}
+	if !strings.Contains(body, `"created":`) {
+		t.Fatalf("body missing created field: %s", body)
+	}
+	if strings.Contains(body, `"created":0`) {
+		t.Fatalf("created field zero: %s", body)
 	}
 }
 

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -57,6 +57,7 @@ type CallFunc struct {
 // 非流式响应
 type ChatResponse struct {
 	ID      string   `json:"id"`
+	Created int64    `json:"created"`
 	Object  string   `json:"object"`
 	Model   string   `json:"model"`
 	Choices []Choice `json:"choices"`
@@ -78,6 +79,7 @@ type Usage struct {
 // 流式响应块
 type ChatStreamChunk struct {
 	ID      string         `json:"id"`
+	Created int64          `json:"created"`
 	Object  string         `json:"object"`
 	Model   string         `json:"model"`
 	Choices []StreamChoice `json:"choices"`


### PR DESCRIPTION
### What's changed
Add missing 'created' timestamps to chat response body so client applications that require 'created' field can parse both non-stream and stream responses correctly.

### Issue
Some OpenAI-compatible clients (e.g. PyCharm’s LLM chat integration) require the 'created' timestamp field to exist in chat completion responses. When it is missing, deserialization fails even if the rest of the response is valid.

This was observed with PyCharm's LLM chat integration which throws an IllegalStateException trying to parse OpenAIChatCompletionStreamResponse when the 'created' field is absent:

> java.lang.IllegalStateException: Error from OpenAILLMClientExt API: 200 OK: Field 'created' is required for type with serial name 'ai.koog.prompt.executor.clients.openai.models.OpenAIChatCompletionStreamResponse', but it was missing at path: $

### Result
This pull request fixes this issue for PyCharm chat and any other app expecting OpenAI-compatible 'created' timestamps in chat responses.

---

### 修改内容
在聊天响应体（chat response body）中补全缺失的 created 时间戳，以便需要 created 字段的客户端应用能够正确解析非流式（non-stream）和流式（stream）响应。

### 问题背景
某些兼容 OpenAI 的客户端（例如 PyCharm 的 LLM 聊天集成）要求聊天补全（chat completion）响应中必须包含 created 时间戳字段。如果该字段缺失，即使响应的其他部分完全有效，反序列化也会失败。
这一问题在 PyCharm 的 LLM 聊天集成中被发现。当 created 字段缺失时，它在尝试解析OpenAIChatCompletionStreamResponse 时会抛出 IllegalStateException 异常：

> java.lang.IllegalStateException: Error from OpenAILLMClientExt API: 200 OK: Field 'created' is required for type with serial name 'ai.koog.prompt.executor.clients.openai.models.OpenAIChatCompletionStreamResponse', but it was missing at path: $

### 结果
本 Pull Request 修复了 PyCharm 聊天以及其他任何期望在聊天响应中获取兼容 OpenAI 的 created 时间戳的应用中所存在的这一问题。