### PR TITLE
fix: stop swallowing and corrupting tool calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ usage.json
 *.exe
 .oauth_state
 .oauth_url
+
+# --debug writes full request bodies and SSE events, so these hold developer
+# prompts and user source. Never commit them.
+log.txt*
+*.log
+*.patch
+changes_report.md

--- a/internal/app/authoritative_test.go
+++ b/internal/app/authoritative_test.go
@@ -1,0 +1,198 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Reproduces the shape captured in log.txt for call_00_QGEcKdSRrV2LHPV5FeUb8382:
+// the buffered deltas were cut off, and the upstream then sent a tool-call event
+// holding the complete input. The client used to receive the truncated
+// reconstruction (14600 bytes) instead of the authoritative payload (42985).
+func TestAuthoritativeToolCallSupersedesRepairedGuess(t *testing.T) {
+	complete := strings.Repeat("A", 4096)
+	n := newCCEventNormalizer()
+	var deduper toolCallDeduper
+
+	consume := func(ev CCStreamEvent) {
+		t.Helper()
+		events, err := n.Consume(ev)
+		if err != nil {
+			t.Fatalf("consume %s: %v", ev.Type, err)
+		}
+		for _, e := range events {
+			if e.kind == normalizedToolCall {
+				deduper.Add(*e.toolCall)
+			}
+		}
+	}
+
+	consume(CCStreamEvent{Type: "tool-input-start", ID: "c1", ToolName: "write"})
+	consume(CCStreamEvent{Type: "tool-input-delta", ID: "c1", Delta: `{"path":"/a.py","content":"trunc`})
+	consume(CCStreamEvent{Type: "tool-input-end", ID: "c1"})
+	consume(CCStreamEvent{Type: "tool-call", ToolCallID: "c1", ToolName: "write",
+		Input: map[string]any{"path": "/a.py", "content": complete}})
+	consume(CCStreamEvent{Type: "finish", FinishReason: "tool-calls"})
+
+	if len(deduper.kept) != 1 {
+		t.Fatalf("expected exactly 1 call, got %d: %+v", len(deduper.kept), deduper.kept)
+	}
+	var args struct{ Content string }
+	if err := json.Unmarshal([]byte(deduper.kept[0].Function.Arguments), &args); err != nil {
+		t.Fatalf("arguments not valid JSON: %v", err)
+	}
+	if args.Content != complete {
+		t.Fatalf("client got %d bytes of content, want the authoritative %d",
+			len(args.Content), len(complete))
+	}
+}
+
+// With no authoritative event, the repaired guess must still be delivered —
+// holding it back must not become a new way to lose a call.
+func TestRepairedCallStillDeliveredWithoutAuthoritative(t *testing.T) {
+	n := newCCEventNormalizer()
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: "c1", ToolName: "bash"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: "c1", Delta: `{"command":"ls`})
+	if events := mustConsume(t, n, CCStreamEvent{Type: "tool-input-end", ID: "c1"}); len(events) != 0 {
+		t.Fatalf("repaired call should be held, got %v", events)
+	}
+
+	events := mustConsume(t, n, CCStreamEvent{Type: "finish", FinishReason: "tool-calls"})
+	call := onlyToolCall(t, events)
+	if call.ID != "c1" || call.Function.Name != "bash" {
+		t.Fatalf("held call not released correctly: %+v", call)
+	}
+	if last := events[len(events)-1]; last.kind != normalizedFinish {
+		t.Fatal("finish must remain last")
+	}
+}
+
+// An aborted stream must also release held calls.
+func TestHeldCallReleasedOnAbort(t *testing.T) {
+	n := newCCEventNormalizer()
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: "c1", ToolName: "bash"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: "c1", Delta: `{"command":"ls`})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-end", ID: "c1"})
+
+	drained, err := n.drainToolInputs()
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if len(drained) != 1 || drained[0].toolCall == nil || drained[0].toolCall.ID != "c1" {
+		t.Fatalf("abort lost the held call: %+v", drained)
+	}
+}
+
+// A tool-error carrying the payload as a pre-encoded JSON string must not be
+// double-encoded: the client has to be able to decode arguments as an object.
+func TestToolErrorStringInputNotDoubleEncoded(t *testing.T) {
+	n := newCCEventNormalizer()
+	events := mustConsume(t, n, CCStreamEvent{
+		Type: "tool-error", ToolCallID: "c1", ToolName: "write",
+		Input: `{"path":"/a.py","content":"x"}`,
+	})
+	call := onlyToolCall(t, events)
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(call.Function.Arguments), &obj); err != nil {
+		t.Fatalf("arguments are double-encoded, client cannot use them: %v (got %s)",
+			err, call.Function.Arguments)
+	}
+	if obj["path"] != "/a.py" {
+		t.Fatalf("wrong arguments: %s", call.Function.Arguments)
+	}
+}
+
+// The non-streaming path must recover buffered calls on an aborted upstream
+// too, and must not discard a partial turn that already holds complete calls.
+func TestNonStreamRecoversOnAbort(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"type":"tool-input-start","id":"c1","toolName":"bash"}`,
+		`data: {"type":"tool-input-delta","id":"c1","delta":"{\"command\":\"ls -la\"}"}`,
+		``, // upstream drops the connection: no tool-input-end, no finish
+	}, "\n\n")
+	rec := httptest.NewRecorder()
+
+	handleNonStream(rec, &http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		"test-model", &UsageTracker{}, &Config{})
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200. body = %s", rec.Code, rec.Body.String())
+	}
+	var out ChatResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	calls := out.Choices[0].Message.ToolCalls
+	if len(calls) != 1 || calls[0].Function.Name != "bash" {
+		t.Fatalf("aborted non-stream lost the buffered call: %+v", calls)
+	}
+	if !strings.Contains(calls[0].Function.Arguments, "ls -la") {
+		t.Fatalf("wrong arguments: %s", calls[0].Function.Arguments)
+	}
+}
+
+// A malformed line after real content must not throw the whole turn away.
+func TestNonStreamKeepsCallsDespiteLateParseError(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"type":"tool-call","toolCallId":"c1","toolName":"bash","input":{"command":"ls"}}`,
+		`data: {oops not json}`,
+		``,
+	}, "\n\n")
+	rec := httptest.NewRecorder()
+
+	handleNonStream(rec, &http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		"test-model", &UsageTracker{}, &Config{})
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (a complete call had already arrived)", rec.Code)
+	}
+	var out ChatResponse
+	json.Unmarshal(rec.Body.Bytes(), &out)
+	if len(out.Choices[0].Message.ToolCalls) != 1 {
+		t.Fatalf("call discarded by the late parse error: %+v", out.Choices[0].Message.ToolCalls)
+	}
+	if got := out.Choices[0].FinishReason; got != "length" {
+		t.Errorf("finish_reason = %q, want \"length\" for a truncated turn", got)
+	}
+}
+
+// A repaired guess that an authoritative event superseded is not a truncation
+// the client needs to hear about: the delivered arguments are complete.
+func TestSupersededRepairDoesNotReportLength(t *testing.T) {
+	n := newCCEventNormalizer()
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: "c1", ToolName: "write"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: "c1", Delta: `{"path":"/a","content":"trunc`})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-end", ID: "c1"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-call", ToolCallID: "c1", ToolName: "write",
+		Input: map[string]any{"path": "/a", "content": "complete"}})
+
+	events := mustConsume(t, n, CCStreamEvent{Type: "finish", FinishReason: "tool-calls"})
+	finish := events[len(events)-1]
+	if finish.truncated {
+		t.Error("superseded repair still flagged the turn as truncated")
+	}
+	if got := resolveFinishReason(finish.finishReason, true, finish.truncated); got != "tool_calls" {
+		t.Errorf("finish_reason = %q, want \"tool_calls\"", got)
+	}
+}
+
+// But a repair that IS delivered must still report length.
+func TestDeliveredRepairReportsLength(t *testing.T) {
+	n := newCCEventNormalizer()
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: "c1", ToolName: "write"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: "c1", Delta: `{"path":"/a","content":"trunc`})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-end", ID: "c1"})
+
+	events := mustConsume(t, n, CCStreamEvent{Type: "finish", FinishReason: "tool-calls"})
+	finish := events[len(events)-1]
+	if !finish.truncated {
+		t.Fatal("delivered repair did not flag truncation")
+	}
+	if got := resolveFinishReason(finish.finishReason, true, finish.truncated); got != "length" {
+		t.Errorf("finish_reason = %q, want \"length\"", got)
+	}
+}

--- a/internal/app/budget_test.go
+++ b/internal/app/budget_test.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Current OpenAI clients send max_completion_tokens; max_tokens is deprecated.
+// Reading only the old field silently discarded the caller's budget.
+func TestOutputTokenBudget(t *testing.T) {
+	cases := []struct {
+		name                string
+		maxTokens, maxCompl int
+		want                int
+	}{
+		{"neither set", 0, 0, 0},
+		{"legacy max_tokens only", 4096, 0, 4096},
+		{"modern max_completion_tokens only", 0, 384000, 384000},
+		{"both set, modern wins", 4096, 384000, 384000},
+	}
+	for _, c := range cases {
+		req := &ChatRequest{MaxTokens: c.maxTokens, MaxCompletionTokens: c.maxCompl}
+		if got := req.OutputTokenBudget(); got != c.want {
+			t.Errorf("%s: OutputTokenBudget() = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestOpenAIToCCUsesCompletionTokenBudget(t *testing.T) {
+	msgs := []Message{{Role: "user", Content: TextContent("hi")}}
+
+	// The exact shape every request in the captured production logs used.
+	cc, err := openAIToCC(&ChatRequest{Model: "m", Messages: msgs, MaxCompletionTokens: 384000})
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if cc.Params.MaxTokens != maximumCCMaxTokens {
+		t.Errorf("max_completion_tokens=384000 gave upstream max_tokens=%d, want the %d clamp",
+			cc.Params.MaxTokens, maximumCCMaxTokens)
+	}
+
+	cc, err = openAIToCC(&ChatRequest{Model: "m", Messages: msgs, MaxCompletionTokens: 8192})
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if cc.Params.MaxTokens != 8192 {
+		t.Errorf("upstream max_tokens = %d, want 8192", cc.Params.MaxTokens)
+	}
+
+	cc, err = openAIToCC(&ChatRequest{Model: "m", Messages: msgs})
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if cc.Params.MaxTokens != defaultCCMaxTokens {
+		t.Errorf("unset budget gave %d, want the %d default", cc.Params.MaxTokens, defaultCCMaxTokens)
+	}
+}
+
+// A tool-call event carries the whole tool input inline. bufio.Scanner's token
+// cap used to abort the scan on such a line, discarding every later event —
+// including finish — so the client saw a stream that simply stopped.
+func TestParseStreamEventsHandlesOversizedLine(t *testing.T) {
+	huge := strings.Repeat("y", 3*1024*1024)
+	body := strings.Join([]string{
+		`data: {"type":"text-delta","text":"before"}`,
+		fmt.Sprintf(`data: {"type":"tool-call","toolCallId":"c1","toolName":"write","input":{"path":"/a","content":%q}}`, huge),
+		`data: {"type":"finish","finishReason":"tool-calls","totalUsage":{"inputTokens":1,"outputTokens":2,"totalTokens":3}}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+
+	var kinds []string
+	var gotContent int
+	err := ParseStreamEvents(
+		&http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		func(ev CCStreamEvent) error {
+			kinds = append(kinds, ev.Type)
+			if ev.Type == "tool-call" {
+				if input, ok := ev.Input.(map[string]any); ok {
+					gotContent = len(input["content"].(string))
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("ParseStreamEvents: %v", err)
+	}
+	want := []string{"text-delta", "tool-call", "finish"}
+	if strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("events = %v, want %v (an oversized line must not truncate the stream)", kinds, want)
+	}
+	if gotContent != len(huge) {
+		t.Fatalf("tool input content = %d bytes, want %d", gotContent, len(huge))
+	}
+}
+
+func TestParseStreamEventsSurvivesMissingTrailingNewline(t *testing.T) {
+	body := `data: {"type":"text-delta","text":"a"}` + "\n\n" +
+		`data: {"type":"finish","finishReason":"stop"}` // no trailing newline
+
+	var kinds []string
+	err := ParseStreamEvents(
+		&http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		func(ev CCStreamEvent) error { kinds = append(kinds, ev.Type); return nil })
+	if err != nil {
+		t.Fatalf("ParseStreamEvents: %v", err)
+	}
+	if strings.Join(kinds, ",") != "text-delta,finish" {
+		t.Fatalf("events = %v, want [text-delta finish]", kinds)
+	}
+}

--- a/internal/app/cc.go
+++ b/internal/app/cc.go
@@ -242,16 +242,11 @@ func ParseStreamEvents(resp *http.Response, onEvent func(CCStreamEvent) error) e
 
 	for {
 		raw, readErr := readSSELine(reader)
-		line := strings.TrimSpace(raw)
-
-		if line != "" && !strings.HasPrefix(line, ":") && !strings.HasPrefix(line, "event:") {
-			if payload, ok := strings.CutPrefix(line, "data:"); ok {
-				line = strings.TrimSpace(payload)
-			}
-			if line == "[DONE]" {
+		if payload, ok := sseDataPayload(raw); ok {
+			if payload == "[DONE]" {
 				return nil
 			}
-			ev, err := decodeSSEEvent(line)
+			ev, err := decodeSSEEvent(payload)
 			if err != nil {
 				return err
 			}
@@ -267,6 +262,41 @@ func ParseStreamEvents(resp *http.Response, onEvent func(CCStreamEvent) error) e
 			return readErr
 		}
 	}
+}
+
+// sseDataPayload returns the payload of a data line, or ok=false for anything
+// that is not one.
+//
+// Per the SSE grammar a line is a "field: value" pair, and only the data field
+// carries the JSON this proxy consumes. Comments (":..."), other fields
+// (event:, id:, retry:) and blank keep-alive lines must be skipped, not handed
+// to the JSON decoder — decoding "id: 42" as JSON would abort the whole stream
+// and lose every event after it.
+func sseDataPayload(raw string) (string, bool) {
+	line := strings.TrimSpace(raw)
+	if line == "" || strings.HasPrefix(line, ":") {
+		return "", false
+	}
+	payload, ok := strings.CutPrefix(line, "data:")
+	if !ok {
+		// Some upstreams stream bare JSON with no field prefix; accept it, but
+		// never a recognised non-data SSE field line.
+		if isSSEFieldLine(line) {
+			return "", false
+		}
+		return line, true
+	}
+	return strings.TrimSpace(payload), true
+}
+
+// isSSEFieldLine reports whether a line begins with a known non-data SSE field.
+func isSSEFieldLine(line string) bool {
+	for _, field := range []string{"event:", "id:", "retry:"} {
+		if strings.HasPrefix(line, field) {
+			return true
+		}
+	}
+	return false
 }
 
 // ====================== 格式转换 ======================

--- a/internal/app/cc.go
+++ b/internal/app/cc.go
@@ -286,7 +286,13 @@ func sseDataPayload(raw string) (string, bool) {
 		}
 		return line, true
 	}
-	return strings.TrimSpace(payload), true
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		// An empty data line is a keep-alive, not an event; decoding "" as JSON
+		// returns io.EOF and would abort the whole stream.
+		return "", false
+	}
+	return payload, true
 }
 
 // isSSEFieldLine reports whether a line begins with a known non-data SSE field.
@@ -454,20 +460,24 @@ func contentToCC(m Message) ([]CCPart, error) {
 
 	// 工具调用
 	for _, tc := range m.ToolCalls {
-		var input map[string]any
-		if tc.Function.Arguments != "" {
-			if err := json.Unmarshal([]byte(tc.Function.Arguments), &input); err != nil {
-				parts = append(parts, CCPart{
-					Type: "text",
-					Text: fmt.Sprintf("Assistant requested tool %s (%s) with invalid arguments: %v", tc.Function.Name, tc.ID, err),
-				})
-				continue
-			}
+		// Pass the arguments through verbatim rather than unmarshalling into a map
+		// and re-marshalling. That round-trip turned every JSON number into a
+		// float64 (corrupting large ids the model must echo back) and HTML-escaped
+		// < and & inside the very history the model reads. Only validate.
+		args := strings.TrimSpace(tc.Function.Arguments)
+		if args == "" {
+			args = "{}"
 		}
-		argsJSON, _ := json.Marshal(input)
+		if !json.Valid([]byte(args)) {
+			parts = append(parts, CCPart{
+				Type: "text",
+				Text: fmt.Sprintf("Assistant requested tool %s (%s) with invalid arguments: %s", tc.Function.Name, tc.ID, args),
+			})
+			continue
+		}
 		parts = append(parts, CCPart{
 			Type: "text",
-			Text: fmt.Sprintf("Assistant requested tool %s (%s) with arguments: %s", tc.Function.Name, tc.ID, string(argsJSON)),
+			Text: fmt.Sprintf("Assistant requested tool %s (%s) with arguments: %s", tc.Function.Name, tc.ID, args),
 		})
 	}
 
@@ -480,11 +490,18 @@ func toolsToCC(tools []Tool) []CCTool {
 	}
 	out := make([]CCTool, 0, len(tools))
 	for _, t := range tools {
+		schema := t.Function.Parameters
+		if len(schema) == 0 {
+			// OpenAI lets a no-argument tool omit parameters, but the upstream
+			// expects every tool to carry a schema. Send the canonical empty
+			// object so one no-arg tool does not invalidate the whole request.
+			schema = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
 		out = append(out, CCTool{
 			Type:        "function",
 			Name:        t.Function.Name,
 			Description: t.Function.Description,
-			InputSchema: t.Function.Parameters,
+			InputSchema: schema,
 		})
 	}
 	return out

--- a/internal/app/cc.go
+++ b/internal/app/cc.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -187,42 +188,85 @@ func (c *CCClient) Send(ctx context.Context, req *ChatRequest) (*http.Response, 
 	return resp, nil
 }
 
+// maxSSELineBytes bounds one SSE line. A tool-call event carries the entire
+// tool input inline, so this must clear the largest response the upstream can
+// produce: maximumCCMaxTokens is roughly 800 KB of text, and JSON escaping
+// inflates that further. Overshooting is reported as an error rather than
+// silently truncating the stream.
+const maxSSELineBytes = 32 * 1024 * 1024
+
+// readSSELine reads one newline-terminated line of any length.
+//
+// bufio.Scanner cannot do this: a token larger than its buffer stops the scan
+// with ErrTooLong, so a single oversized tool-call event would discard every
+// event after it — including the finish event — and the client would see a
+// stream that just stops.
+func readSSELine(r *bufio.Reader) (string, error) {
+	var line strings.Builder
+	for {
+		chunk, isPrefix, err := r.ReadLine()
+		if line.Len()+len(chunk) > maxSSELineBytes {
+			return "", fmt.Errorf("sse line exceeds %d bytes", maxSSELineBytes)
+		}
+		line.Write(chunk)
+		if err != nil {
+			return line.String(), err
+		}
+		if !isPrefix {
+			return line.String(), nil
+		}
+	}
+}
+
+func decodeSSEEvent(payload string) (CCStreamEvent, error) {
+	var ev CCStreamEvent
+	decoder := json.NewDecoder(strings.NewReader(payload))
+	decoder.UseNumber()
+	if err := decoder.Decode(&ev); err != nil {
+		return ev, fmt.Errorf("parse sse data: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values")
+		}
+		return ev, fmt.Errorf("parse sse data: trailing content: %w", err)
+	}
+	return ev, nil
+}
+
 // ParseStreamEvents 从 resp.Body 读取 SSE 流，逐事件回调 onEvent。
 func ParseStreamEvents(resp *http.Response, onEvent func(CCStreamEvent) error) error {
 	defer resp.Body.Close()
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	reader := bufio.NewReaderSize(resp.Body, 64*1024)
 
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, ":") || strings.HasPrefix(line, "event:") {
-			continue
-		}
-		if strings.HasPrefix(line, "data:") {
-			line = strings.TrimPrefix(line, "data:")
-			line = strings.TrimSpace(line)
-		}
-		if line == "[DONE]" {
-			break
-		}
-		var ev CCStreamEvent
-		decoder := json.NewDecoder(strings.NewReader(line))
-		decoder.UseNumber()
-		if err := decoder.Decode(&ev); err != nil {
-			return fmt.Errorf("parse sse data: %w", err)
-		}
-		var trailing any
-		if err := decoder.Decode(&trailing); err != io.EOF {
-			if err == nil {
-				err = fmt.Errorf("multiple JSON values")
+	for {
+		raw, readErr := readSSELine(reader)
+		line := strings.TrimSpace(raw)
+
+		if line != "" && !strings.HasPrefix(line, ":") && !strings.HasPrefix(line, "event:") {
+			if payload, ok := strings.CutPrefix(line, "data:"); ok {
+				line = strings.TrimSpace(payload)
 			}
-			return fmt.Errorf("parse sse data: trailing content: %w", err)
+			if line == "[DONE]" {
+				return nil
+			}
+			ev, err := decodeSSEEvent(line)
+			if err != nil {
+				return err
+			}
+			if err := onEvent(ev); err != nil {
+				return err
+			}
 		}
-		if err := onEvent(ev); err != nil {
-			return err
+
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return nil
+			}
+			return readErr
 		}
 	}
-	return scanner.Err()
 }
 
 // ====================== 格式转换 ======================
@@ -286,7 +330,7 @@ func openAIToCC(req *ChatRequest) (CCRequest, error) {
 			Messages:  msgs,
 			Tools:     tools,
 			System:    system,
-			MaxTokens: req.MaxTokens,
+			MaxTokens: req.OutputTokenBudget(),
 			Stream:    true, // CC API 只支持流式
 		},
 	}

--- a/internal/app/closure_test.go
+++ b/internal/app/closure_test.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// A non-final scannable segment's incomplete tail must not be discarded when a
+// later segment overwrites the carried-forward remainder.
+func TestNonFinalSegmentTailPreserved(t *testing.T) {
+	rejected := "<｜｜DSML｜｜tool_calls><invoke name=\"read\">" +
+		"<parameter name=\"path\" string=\"TRUE\">x</parameter></invoke></｜｜DSML｜｜tool_calls>"
+	p := NewToolCallParser()
+	content, calls := p.Feed(
+		`Assistant requested tool bash (id1) with arguments: {"command":"ls"} `+
+			`Assistant requested tool bash (id2) with arguments: {"comm`+rejected, true)
+
+	var ids []string
+	for _, c := range calls {
+		ids = append(ids, c.ID)
+		if c.Function.Name == "read" {
+			t.Errorf("rejected envelope became executable: %+v", c)
+		}
+	}
+	if !containsID(ids, "id1") {
+		t.Fatalf("complete call id1 was lost; calls=%+v", calls)
+	}
+	if !strings.Contains(content, "id2") && !strings.Contains(content, `{"comm`) {
+		t.Errorf("incomplete tail of a non-final segment was dropped; content=%q", content)
+	}
+}
+
+// No event may be written after [DONE]: an OpenAI client stops reading there.
+func TestNoEmissionAfterDone(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"type":"finish","finishReason":"stop","totalUsage":{"inputTokens":1,"outputTokens":2}}`,
+		`data: {"type":"tool-call","toolCallId":"late","toolName":"bash","input":{"command":"ls"}}`,
+		`data: {"type":"text-delta","text":"trailing"}`,
+		`data: [DONE]`,
+	}, "\n\n")
+	rec := httptest.NewRecorder()
+	handleStream(rec, &http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		"m", &UsageTracker{}, &Config{})
+
+	out := rec.Body.String()
+	done := strings.Index(out, "data: [DONE]")
+	if done < 0 {
+		t.Fatal("stream did not terminate with [DONE]")
+	}
+	if after := out[done+len("data: [DONE]"):]; strings.Contains(after, `"late"`) ||
+		strings.Contains(after, "trailing") {
+		t.Fatalf("content written after [DONE]: %q", after)
+	}
+}
+
+// The normal finish flush still delivers a call buffered right up to finish —
+// the done guard must not suppress the final drain.
+func TestFinishFlushStillEmits(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"type":"tool-input-start","id":"c1","toolName":"bash"}`,
+		`data: {"type":"tool-input-delta","id":"c1","delta":"{\"command\":\"ls\"}"}`,
+		`data: {"type":"finish","finishReason":"tool-calls","totalUsage":{"inputTokens":1,"outputTokens":2}}`,
+		`data: [DONE]`,
+	}, "\n\n")
+	rec := httptest.NewRecorder()
+	handleStream(rec, &http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		"m", &UsageTracker{}, &Config{})
+
+	out := rec.Body.String()
+	if !strings.Contains(out, `"name":"bash"`) {
+		t.Fatalf("finish flush dropped the buffered call: %s", out)
+	}
+	if n := strings.Count(out, "data: [DONE]"); n != 1 {
+		t.Fatalf("got %d [DONE] markers, want 1", n)
+	}
+}
+
+// Non-data SSE field lines must be skipped, not decoded — decoding one would
+// abort the whole stream and lose every later event.
+func TestSSEFieldLinesSkipped(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"type":"text-delta","text":"a"}`,
+		`id: 42`,
+		`retry: 1000`,
+		`event: message`,
+		`: keepalive comment`,
+		`data: {"type":"tool-call","toolCallId":"c1","toolName":"bash","input":{"command":"ls"}}`,
+		`data: {"type":"finish","finishReason":"tool-calls"}`,
+	}, "\n\n")
+	var kinds []string
+	err := ParseStreamEvents(&http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		func(ev CCStreamEvent) error { kinds = append(kinds, ev.Type); return nil })
+	if err != nil {
+		t.Fatalf("a non-data field line aborted the stream: %v (events=%v)", err, kinds)
+	}
+	if strings.Join(kinds, ",") != "text-delta,tool-call,finish" {
+		t.Fatalf("events lost around field lines: %v", kinds)
+	}
+}
+
+// The write fallback must never fabricate content:"" — executing that would
+// truncate the target file to zero bytes.
+func TestWriteFallbackNeverFabricatesEmptyContent(t *testing.T) {
+	got := repairOrFallbackToolInput(`totally not json`, "write")
+	if strings.Contains(got, `"content"`) {
+		t.Fatalf("write fallback fabricated a content field: %s", got)
+	}
+}
+
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/dsmlrecovery_test.go
+++ b/internal/app/dsmlrecovery_test.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const dsmlOpen = "<｜｜DSML｜｜tool_calls>"
+const dsmlClose = "</｜｜DSML｜｜tool_calls>"
+
+// The previously-unrecoverable shapes: real bash/write payloads.
+func TestDSMLDSMLRealisticPayloads(t *testing.T) {
+	cases := []struct{ name, param, want string }{
+		{"ampersand", "make && make test", "make && make test"},
+		{"heredoc", "cat <<EOF", "cat <<EOF"},
+		{"html", `grep -rE '<div class="x">' /srv`, `grep -rE '<div class="x">' /srv`},
+		{"mixed", "a < b && c > d", "a < b && c > d"},
+		{"entity-preserved", "x &amp; y", "x & y"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := dsmlOpen + `<invoke name="bash"><parameter name="command" string="true">` + c.param + `</parameter></invoke>` + dsmlClose
+			content, calls := NewToolCallParser().Feed(in, true)
+			if len(calls) != 1 {
+				t.Fatalf("lost the call: %d calls, content=%q", len(calls), content)
+			}
+			var args map[string]string
+			if err := json.Unmarshal([]byte(calls[0].Function.Arguments), &args); err != nil {
+				t.Fatalf("bad arguments JSON: %v", err)
+			}
+			if args["command"] != c.want {
+				t.Fatalf("command = %q, want %q", args["command"], c.want)
+			}
+		})
+	}
+}
+
+// A malformed envelope must no longer take down a valid co-buffered call.
+func TestDSMLMalformedEnvelopeDoesNotPoison(t *testing.T) {
+	good := `Assistant requested tool bash (call_1) with arguments: {"command":"ls"}`
+	bad := dsmlOpen + `<invoke name="read"><parameter name="path" string="TRUE">a</parameter></invoke>` + dsmlClose
+	content, calls := NewToolCallParser().Feed(good+"\n"+bad, true)
+	if len(calls) != 1 {
+		t.Fatalf("valid call lost: %d calls", len(calls))
+	}
+	if calls[0].ID != "call_1" {
+		t.Fatalf("wrong call survived: %+v", calls[0])
+	}
+	if !strings.Contains(content, "TRUE") {
+		t.Errorf("malformed envelope should still be visible to the client: %q", content)
+	}
+}
+
+// Security: text inside a REJECTED envelope must never become executable.
+func TestDSMLRejectedEnvelopeIsNotExecutable(t *testing.T) {
+	inject := dsmlOpen + `<invoke name="read"><parameter name="path" string="true">a</parameter></invoke>` +
+		`Assistant requested tool bash (call_unsafe) with arguments: {"command":"echo unsafe"}` + dsmlClose
+	content, calls := NewToolCallParser().Feed(inject, true)
+	for _, c := range calls {
+		if c.ID == "call_unsafe" {
+			t.Fatalf("INJECTION: rejected envelope text became an executable call")
+		}
+	}
+	if content != inject {
+		t.Errorf("rejected envelope not preserved verbatim")
+	}
+}
+
+// Multiple invokes in one envelope still all survive.
+func TestDSMLMultipleInvokesWithSpecialChars(t *testing.T) {
+	in := dsmlOpen +
+		`<invoke name="bash"><parameter name="command" string="true">a && b</parameter></invoke>` +
+		`<invoke name="write"><parameter name="path" string="true">/x</parameter><parameter name="content" string="true">if (a<b) {}</parameter></invoke>` +
+		dsmlClose
+	_, calls := NewToolCallParser().Feed(in, true)
+	if len(calls) != 2 {
+		t.Fatalf("got %d calls, want 2", len(calls))
+	}
+	var w map[string]string
+	json.Unmarshal([]byte(calls[1].Function.Arguments), &w)
+	if w["content"] != "if (a<b) {}" {
+		t.Fatalf("content = %q", w["content"])
+	}
+}
+
+// A bare number or literal argument split across deltas must not be emitted
+// as the truncated prefix.
+func TestSplitScalarArgumentNotTruncated(t *testing.T) {
+	cases := []struct{ head, tail, want string }{
+		{"12", "345", "12345"},
+		{"tr", "ue", "true"},
+		{"nu", "ll", "null"},
+		{"-1.5", "e10", "-1.5e10"},
+	}
+	for _, c := range cases {
+		p := NewToolCallParser()
+		_, k1 := p.Feed(`Assistant requested tool t (id) with arguments: `+c.head, false)
+		_, k2 := p.Feed(c.tail, true)
+		all := append(k1, k2...)
+		if len(all) != 1 {
+			t.Fatalf("%s|%s: got %d calls, want 1", c.head, c.tail, len(all))
+		}
+		if got := all[0].Function.Arguments; got != c.want {
+			t.Errorf("%s|%s: arguments = %q, want %q", c.head, c.tail, got, c.want)
+		}
+	}
+}
+
+// A scalar argument that is already complete at end of stream still resolves.
+func TestScalarArgumentAtStreamEnd(t *testing.T) {
+	p := NewToolCallParser()
+	_, calls := p.Feed(`Assistant requested tool t (id) with arguments: 42`, true)
+	if len(calls) != 1 || calls[0].Function.Arguments != "42" {
+		t.Fatalf("got %d calls %+v", len(calls), calls)
+	}
+}

--- a/internal/app/events.go
+++ b/internal/app/events.go
@@ -386,8 +386,17 @@ func parseToolInputObject(raw string, depth int) (map[string]any, bool) {
 }
 
 func decodeToolInputObject(raw string, depth int) (map[string]any, bool) {
+	// UseNumber keeps integers exact. A plain json.Unmarshal into any turns every
+	// number into a float64, so re-marshalling a 19-digit id like a Discord
+	// snowflake or a nanosecond timestamp would silently round it — the repaired
+	// call would then act on the wrong resource with no error anywhere.
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
 	var value any
-	if json.Unmarshal([]byte(raw), &value) != nil {
+	if decoder.Decode(&value) != nil {
+		return nil, false
+	}
+	if decoder.More() {
 		return nil, false
 	}
 	switch typed := value.(type) {

--- a/internal/app/events.go
+++ b/internal/app/events.go
@@ -26,15 +26,23 @@ type normalizedCCEvent struct {
 	toolCall     *ToolCall
 	finishReason string
 	usage        Usage
+	// truncated reports that at least one tool input arrived incomplete and had
+	// to be repaired. The client must not be told the turn ended cleanly.
+	truncated bool
 }
 
 type ccEventNormalizer struct {
 	toolInputBuf      map[string]string
 	toolInputToolName map[string]string
-	usage             Usage
-	cacheRead         int
-	cacheWrite        int
-	finished          bool
+	// toolInputOrder preserves arrival order so a drain at end-of-stream emits
+	// buffered calls in the order the model produced them. Map iteration order
+	// would otherwise shuffle them.
+	toolInputOrder []string
+	usage          Usage
+	cacheRead      int
+	cacheWrite     int
+	finished       bool
+	truncated      bool
 }
 
 func newCCEventNormalizer() *ccEventNormalizer {
@@ -59,6 +67,7 @@ func (n *ccEventNormalizer) Consume(ev CCStreamEvent) ([]normalizedCCEvent, erro
 	case "tool-input-start":
 		id := eventToolCallID(ev)
 		if id != "" {
+			n.trackToolInput(id)
 			n.toolInputBuf[id] = ""
 			n.toolInputToolName[id] = ev.ToolName
 		}
@@ -66,13 +75,18 @@ func (n *ccEventNormalizer) Consume(ev CCStreamEvent) ([]normalizedCCEvent, erro
 	case "tool-input-delta":
 		id := eventToolCallID(ev)
 		if id != "" {
+			n.trackToolInput(id)
 			n.toolInputBuf[id] += ev.Delta
 			if ev.ToolName != "" {
 				n.toolInputToolName[id] = ev.ToolName
 			}
 		}
 		return nil, nil
-	case "tool-input-end", "tool-input-available":
+	case "tool-input-end", "tool-input-available", "tool-error":
+		// tool-error carries the same identifiers as tool-input-end and can
+		// arrive in its place. Treat it as a terminator so the buffered input is
+		// emitted instead of being dropped; a duplicate is suppressed downstream
+		// by toolCallDeduper.
 		call, ok, err := n.finishToolInput(ev)
 		if err != nil {
 			return nil, err
@@ -94,11 +108,19 @@ func (n *ccEventNormalizer) Consume(ev CCStreamEvent) ([]normalizedCCEvent, erro
 			n.setUsage(ev.TotalUsage)
 		}
 		n.finished = true
-		return []normalizedCCEvent{{
+		// The upstream can end a stream while tool inputs are still buffered,
+		// for example when it is cut off by the output-token cap. Emit them
+		// rather than dropping the model's intent on the floor.
+		out, err := n.drainToolInputs()
+		if err != nil {
+			return nil, err
+		}
+		return append(out, normalizedCCEvent{
 			kind:         normalizedFinish,
 			finishReason: normalizeFinishReason(ev.FinishReason),
 			usage:        n.usage,
-		}}, nil
+			truncated:    n.truncated,
+		}), nil
 	case "text-end":
 		return []normalizedCCEvent{{kind: normalizedTextEnd}}, nil
 	case "reasoning-end":
@@ -142,6 +164,57 @@ func (n *ccEventNormalizer) setUsage(usage *CCUsage) {
 	}
 }
 
+// trackToolInput registers an id on first sight so drainToolInputs can replay
+// buffered inputs in arrival order.
+func (n *ccEventNormalizer) trackToolInput(id string) {
+	if _, seen := n.toolInputBuf[id]; seen {
+		return
+	}
+	n.toolInputBuf[id] = ""
+	n.toolInputOrder = append(n.toolInputOrder, id)
+}
+
+func (n *ccEventNormalizer) forgetToolInput(id string) {
+	delete(n.toolInputBuf, id)
+	delete(n.toolInputToolName, id)
+	for i, pending := range n.toolInputOrder {
+		if pending == id {
+			n.toolInputOrder = append(n.toolInputOrder[:i], n.toolInputOrder[i+1:]...)
+			break
+		}
+	}
+}
+
+// drainToolInputs emits every tool input still buffered when the stream ends.
+// Without this, an upstream that never sends tool-input-end silently discards
+// the call.
+func (n *ccEventNormalizer) drainToolInputs() ([]normalizedCCEvent, error) {
+	if len(n.toolInputOrder) == 0 {
+		return nil, nil
+	}
+	pending := append([]string(nil), n.toolInputOrder...)
+	out := make([]normalizedCCEvent, 0, len(pending))
+	for _, id := range pending {
+		if n.toolInputBuf[id] == "" {
+			// Nothing was ever buffered for this id; there is no call to recover.
+			n.forgetToolInput(id)
+			continue
+		}
+		log.Printf("%s stream ended with tool input %q (tool %q) still buffered; recovering it",
+			colorize("[WARN]", ansiYellow), id, n.toolInputToolName[id])
+		call, ok, err := n.finishToolInput(CCStreamEvent{Type: "tool-input-end", ID: id})
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		toolCall := call
+		out = append(out, normalizedCCEvent{kind: normalizedToolCall, toolCall: &toolCall})
+	}
+	return out, nil
+}
+
 func (n *ccEventNormalizer) finishToolInput(ev CCStreamEvent) (ToolCall, bool, error) {
 	id := eventToolCallID(ev)
 	name := n.toolInputToolName[id]
@@ -149,8 +222,7 @@ func (n *ccEventNormalizer) finishToolInput(ev CCStreamEvent) (ToolCall, bool, e
 		name = ev.ToolName
 	}
 	raw := n.toolInputBuf[id]
-	delete(n.toolInputBuf, id)
-	delete(n.toolInputToolName, id)
+	n.forgetToolInput(id)
 
 	if raw == "" {
 		input := eventToolInput(ev)
@@ -166,11 +238,17 @@ func (n *ccEventNormalizer) finishToolInput(ev CCStreamEvent) (ToolCall, bool, e
 		var input any
 		if err := json.Unmarshal([]byte(raw), &input); err != nil {
 			log.Printf("%s parse tool input %q for tool %q failed: %v, attempting repair/fallback", colorize("[WARN]", ansiYellow), id, name, err)
+			// The arguments the model produced were cut off. Remember it so the
+			// finish chunk can report "length" instead of claiming a clean
+			// tool_calls turn.
+			n.truncated = true
 			raw = repairOrFallbackToolInput(raw, name)
 		}
 	}
 
 	if id == "" || name == "" {
+		log.Printf("%s dropping tool call with empty id/name (id=%q name=%q, %d bytes of arguments)",
+			colorize("[WARN]", ansiYellow), id, name, len(raw))
 		return ToolCall{}, false, nil
 	}
 	return ToolCall{

--- a/internal/app/events.go
+++ b/internal/app/events.go
@@ -38,17 +38,22 @@ type ccEventNormalizer struct {
 	// buffered calls in the order the model produced them. Map iteration order
 	// would otherwise shuffle them.
 	toolInputOrder []string
-	usage          Usage
-	cacheRead      int
-	cacheWrite     int
-	finished       bool
-	truncated      bool
+	// heldCalls holds repair-derived calls until the stream ends, so an
+	// authoritative tool-call event can supersede them.
+	heldCalls  map[string]ToolCall
+	heldOrder  []string
+	usage      Usage
+	cacheRead  int
+	cacheWrite int
+	finished   bool
+	truncated  bool
 }
 
 func newCCEventNormalizer() *ccEventNormalizer {
 	return &ccEventNormalizer{
 		toolInputBuf:      make(map[string]string),
 		toolInputToolName: make(map[string]string),
+		heldCalls:         make(map[string]ToolCall),
 	}
 }
 
@@ -63,6 +68,9 @@ func (n *ccEventNormalizer) Consume(ev CCStreamEvent) ([]normalizedCCEvent, erro
 		if err != nil {
 			return nil, err
 		}
+		// This event carries the upstream's own complete input, so it supersedes
+		// anything reconstructed from deltas for the same id.
+		n.dropHeldCall(call.ID)
 		return []normalizedCCEvent{{kind: normalizedToolCall, toolCall: &call}}, nil
 	case "tool-input-start":
 		id := eventToolCallID(ev)
@@ -92,6 +100,14 @@ func (n *ccEventNormalizer) Consume(ev CCStreamEvent) ([]normalizedCCEvent, erro
 			return nil, err
 		}
 		if !ok {
+			return nil, nil
+		}
+		if call.repaired {
+			// The deltas were cut off and only parse because repair patched
+			// them. The upstream usually follows with a tool-call event holding
+			// the complete input, so hold this guess back rather than racing it
+			// to the client — once emitted, a streamed call cannot be corrected.
+			n.holdCall(call)
 			return nil, nil
 		}
 		return []normalizedCCEvent{{kind: normalizedToolCall, toolCall: &call}}, nil
@@ -164,6 +180,53 @@ func (n *ccEventNormalizer) setUsage(usage *CCUsage) {
 	}
 }
 
+// holdCall parks a repair-derived call until the stream ends, so a later
+// authoritative tool-call event for the same id can replace it.
+func (n *ccEventNormalizer) holdCall(call ToolCall) {
+	if _, seen := n.heldCalls[call.ID]; !seen {
+		n.heldOrder = append(n.heldOrder, call.ID)
+	}
+	n.heldCalls[call.ID] = call
+}
+
+func (n *ccEventNormalizer) dropHeldCall(id string) {
+	if _, held := n.heldCalls[id]; !held {
+		return
+	}
+	delete(n.heldCalls, id)
+	for i, pending := range n.heldOrder {
+		if pending == id {
+			n.heldOrder = append(n.heldOrder[:i], n.heldOrder[i+1:]...)
+			break
+		}
+	}
+}
+
+// releaseHeldCalls emits the repair-derived calls no authoritative event
+// superseded. They are the model's intent as best it can be reconstructed, so
+// dropping them would lose the call entirely.
+func (n *ccEventNormalizer) releaseHeldCalls() []normalizedCCEvent {
+	out := make([]normalizedCCEvent, 0, len(n.heldOrder))
+	for _, id := range n.heldOrder {
+		call := n.heldCalls[id]
+		delete(n.heldCalls, id)
+		toolCall := call
+		// A repaired guess is only a truncation the client must know about once
+		// it is the version actually delivered. If an authoritative event had
+		// superseded it, it would never reach here.
+		n.markTruncated(toolCall)
+		out = append(out, normalizedCCEvent{kind: normalizedToolCall, toolCall: &toolCall})
+	}
+	n.heldOrder = nil
+	return out
+}
+
+func (n *ccEventNormalizer) markTruncated(call ToolCall) {
+	if call.repaired {
+		n.truncated = true
+	}
+}
+
 // trackToolInput registers an id on first sight so drainToolInputs can replay
 // buffered inputs in arrival order.
 func (n *ccEventNormalizer) trackToolInput(id string) {
@@ -189,9 +252,6 @@ func (n *ccEventNormalizer) forgetToolInput(id string) {
 // Without this, an upstream that never sends tool-input-end silently discards
 // the call.
 func (n *ccEventNormalizer) drainToolInputs() ([]normalizedCCEvent, error) {
-	if len(n.toolInputOrder) == 0 {
-		return nil, nil
-	}
 	pending := append([]string(nil), n.toolInputOrder...)
 	out := make([]normalizedCCEvent, 0, len(pending))
 	for _, id := range pending {
@@ -210,9 +270,11 @@ func (n *ccEventNormalizer) drainToolInputs() ([]normalizedCCEvent, error) {
 			continue
 		}
 		toolCall := call
+		n.markTruncated(toolCall)
 		out = append(out, normalizedCCEvent{kind: normalizedToolCall, toolCall: &toolCall})
 	}
-	return out, nil
+	// Nothing more can supersede a held call once the stream is over.
+	return append(out, n.releaseHeldCalls()...), nil
 }
 
 func (n *ccEventNormalizer) finishToolInput(ev CCStreamEvent) (ToolCall, bool, error) {
@@ -223,25 +285,23 @@ func (n *ccEventNormalizer) finishToolInput(ev CCStreamEvent) (ToolCall, bool, e
 	}
 	raw := n.toolInputBuf[id]
 	n.forgetToolInput(id)
+	repaired := false
 
 	if raw == "" {
 		input := eventToolInput(ev)
 		if input == nil {
 			return ToolCall{}, false, nil
 		}
-		encoded, err := json.Marshal(input)
+		encoded, err := marshalToolInput(input)
 		if err != nil {
 			return ToolCall{}, false, fmt.Errorf("marshal tool input %q: %w", id, err)
 		}
-		raw = string(encoded)
+		raw = encoded
 	} else {
 		var input any
 		if err := json.Unmarshal([]byte(raw), &input); err != nil {
 			log.Printf("%s parse tool input %q for tool %q failed: %v, attempting repair/fallback", colorize("[WARN]", ansiYellow), id, name, err)
-			// The arguments the model produced were cut off. Remember it so the
-			// finish chunk can report "length" instead of claiming a clean
-			// tool_calls turn.
-			n.truncated = true
+			repaired = true
 			raw = repairOrFallbackToolInput(raw, name)
 		}
 	}
@@ -252,8 +312,9 @@ func (n *ccEventNormalizer) finishToolInput(ev CCStreamEvent) (ToolCall, bool, e
 		return ToolCall{}, false, nil
 	}
 	return ToolCall{
-		ID:   id,
-		Type: "function",
+		ID:       id,
+		Type:     "function",
+		repaired: repaired,
 		Function: CallFunc{
 			Name:      name,
 			Arguments: raw,
@@ -468,8 +529,30 @@ func tryRepairJSON(s string) (string, bool) {
 	return "", false
 }
 
+// marshalToolInput renders an event's tool input as the JSON object the OpenAI
+// arguments field must contain.
+//
+// The upstream is inconsistent: tool-call events carry input as an object,
+// while tool-error events carry the same payload as a pre-encoded JSON string.
+// Marshalling a string yields a quoted string, so the client's json.loads
+// returns text instead of arguments and the call is unusable. Pass through a
+// string that is already valid JSON.
+func marshalToolInput(input any) (string, error) {
+	if text, ok := input.(string); ok {
+		trimmed := strings.TrimSpace(text)
+		if json.Valid([]byte(trimmed)) {
+			return trimmed, nil
+		}
+	}
+	encoded, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
 func toolCallFromEvent(ev CCStreamEvent) (ToolCall, error) {
-	encoded, err := json.Marshal(eventToolInput(ev))
+	encoded, err := marshalToolInput(eventToolInput(ev))
 	if err != nil {
 		return ToolCall{}, fmt.Errorf("marshal tool call %q: %w", eventToolCallID(ev), err)
 	}
@@ -478,7 +561,7 @@ func toolCallFromEvent(ev CCStreamEvent) (ToolCall, error) {
 		Type: "function",
 		Function: CallFunc{
 			Name:      ev.ToolName,
-			Arguments: string(encoded),
+			Arguments: encoded,
 		},
 	}, nil
 }

--- a/internal/app/events.go
+++ b/internal/app/events.go
@@ -346,8 +346,11 @@ func repairOrFallbackToolInput(raw string, toolName string) string {
 	case "read", "view", "cat":
 		fallback["path"] = raw
 	case "write":
+		// Never fabricate content:"" — a client executing that would truncate
+		// the target file to zero bytes. Omitting the required content field
+		// makes the call fail schema validation instead, so the model gets an
+		// actionable error rather than destroying a file.
 		fallback["path"] = raw
-		fallback["content"] = ""
 	default:
 		fallback["command"] = raw
 		fallback["input"] = raw

--- a/internal/app/events_test.go
+++ b/internal/app/events_test.go
@@ -161,7 +161,10 @@ func TestMalformedToolInputInStream(t *testing.T) {
 		}
 	}
 
-	// Send tool-input-end
+	// tool-input-end repairs the truncated deltas, but the call is held rather
+	// than emitted: an authoritative tool-call event for the same id may still
+	// arrive with the complete input, and a streamed call cannot be corrected
+	// once sent.
 	events, err := normalizer.Consume(CCStreamEvent{
 		Type: "tool-input-end",
 		ID:   callID,
@@ -169,8 +172,17 @@ func TestMalformedToolInputInStream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected tool-input-end to succeed with repair/fallback, got error: %v", err)
 	}
-	if len(events) != 1 || events[0].kind != normalizedToolCall {
-		t.Fatalf("expected 1 normalizedToolCall event, got %v", events)
+	if len(events) != 0 {
+		t.Fatalf("expected the repaired call to be held, got %v", events)
+	}
+
+	// No authoritative event arrived, so finish releases the repaired call.
+	events, err = normalizer.Consume(CCStreamEvent{Type: "finish", FinishReason: "tool-calls"})
+	if err != nil {
+		t.Fatalf("unexpected error on finish: %v", err)
+	}
+	if len(events) != 2 || events[0].kind != normalizedToolCall {
+		t.Fatalf("expected the held call then finish, got %v", events)
 	}
 
 	tc := events[0].toolCall

--- a/internal/app/handler.go
+++ b/internal/app/handler.go
@@ -201,10 +201,7 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 				flushParser(reasoningParser, true)
 				flushParser(textParser, false)
 
-				finish := event.finishReason
-				if hasToolCalls {
-					finish = "tool_calls"
-				}
+				finish := resolveFinishReason(event.finishReason, hasToolCalls, event.truncated)
 				usageInfo := event.usage
 				writeSSE(w, flusher, ChatStreamChunk{
 					ID:     genStreamID(),
@@ -243,6 +240,7 @@ func handleNonStream(w http.ResponseWriter, resp *http.Response, model string, u
 	var textContent strings.Builder
 	var reasoningContent strings.Builder
 	var finishReason string
+	var truncated bool
 
 	err := ParseStreamEvents(resp, func(ev CCStreamEvent) error {
 		if cfg.Debug {
@@ -265,6 +263,7 @@ func handleNonStream(w http.ResponseWriter, resp *http.Response, model string, u
 				}
 			case normalizedFinish:
 				finishReason = event.finishReason
+				truncated = event.truncated
 			}
 		}
 		return nil
@@ -304,9 +303,7 @@ func handleNonStream(w http.ResponseWriter, resp *http.Response, model string, u
 
 	msg.Content = TextContent(visibleText)
 	msg.ToolCalls = toolCalls.kept
-	if len(msg.ToolCalls) > 0 {
-		finishReason = "tool_calls"
-	}
+	finishReason = resolveFinishReason(finishReason, len(msg.ToolCalls) > 0, truncated)
 	if reasoningText != "" {
 		msg.ReasoningContent = reasoningText
 	}
@@ -388,6 +385,24 @@ func streamEventText(ev CCStreamEvent) string {
 		return ev.Text
 	}
 	return ev.Delta
+}
+
+// resolveFinishReason picks the OpenAI finish_reason for a completed turn.
+//
+// "tool_calls" tells the client the assistant produced a complete set of calls
+// it may now execute. That claim is false when the upstream hit its output cap:
+// the last tool's arguments were cut off mid-JSON and only survive because
+// repairOrFallbackToolInput patched them into valid syntax. Reporting "length"
+// keeps the truncation visible so the client can retry or refuse instead of
+// executing a silently truncated write.
+func resolveFinishReason(upstream string, hasToolCalls, truncated bool) string {
+	if upstream == "length" || truncated {
+		return "length"
+	}
+	if hasToolCalls {
+		return "tool_calls"
+	}
+	return upstream
 }
 
 func normalizeFinishReason(reason string) string {

--- a/internal/app/handler.go
+++ b/internal/app/handler.go
@@ -163,6 +163,37 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 		}
 	}
 
+	// finishStream emits everything still held back, then the terminating chunk
+	// and [DONE]. It runs for a normal finish event and again after the read
+	// loop returns, so a stream the upstream abandons mid-tool-call still
+	// delivers that call and still terminates in a shape OpenAI clients accept.
+	finishStream := func(reason string, usageInfo Usage, truncated bool) {
+		if done {
+			return
+		}
+		done = true
+		flushParser(reasoningParser, true)
+		flushParser(textParser, false)
+
+		finish := resolveFinishReason(reason, hasToolCalls, truncated)
+		writeSSE(w, flusher, ChatStreamChunk{
+			ID:     genStreamID(),
+			Object: "chat.completion.chunk",
+			Model:  model,
+			Choices: []StreamChoice{{
+				Index:        0,
+				Delta:        StreamDelta{},
+				FinishReason: &finish,
+			}},
+			Usage: &usageInfo,
+		})
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		if debugMode {
+			log.Printf("%s %s", colorize("[DEBUG]", ansiDim), colorize(">> [DONE]", ansiGreen))
+		}
+		flusher.Flush()
+	}
+
 	err := ParseStreamEvents(resp, func(ev CCStreamEvent) error {
 		if cfg.Debug {
 			raw, _ := json.Marshal(ev)
@@ -195,32 +226,7 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 			case normalizedTextEnd:
 				flushParser(textParser, false)
 			case normalizedFinish:
-				if done {
-					continue
-				}
-				flushParser(reasoningParser, true)
-				flushParser(textParser, false)
-
-				finish := resolveFinishReason(event.finishReason, hasToolCalls, event.truncated)
-				usageInfo := event.usage
-				writeSSE(w, flusher, ChatStreamChunk{
-					ID:     genStreamID(),
-					Object: "chat.completion.chunk",
-					Model:  model,
-					Choices: []StreamChoice{{
-						Index:        0,
-						Delta:        StreamDelta{},
-						FinishReason: &finish,
-					}},
-					Usage: &usageInfo,
-				})
-
-				done = true
-				fmt.Fprintf(w, "data: [DONE]\n\n")
-				if debugMode {
-					log.Printf("%s %s", colorize("[DEBUG]", ansiDim), colorize(">> [DONE]", ansiGreen))
-				}
-				flusher.Flush()
+				finishStream(event.finishReason, event.usage, event.truncated)
 			}
 		}
 		return nil
@@ -229,6 +235,34 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 	if err != nil {
 		log.Printf("%s stream parse: %v", colorize("[ERROR]", ansiRed), err)
 	}
+
+	// The upstream can stop without ever sending finish — a dropped connection,
+	// a mid-stream error, or a truncated response. Recover whatever it already
+	// told us rather than leaving the client with a stream that just stops.
+	if !done {
+		// The turn did not complete. "length" is the OpenAI value for a response
+		// that was cut off; reporting "stop" would repeat the lie that a partial
+		// turn finished cleanly.
+		reason := "stop"
+		if err != nil {
+			reason = "length"
+		}
+		drained, drainErr := normalizer.drainToolInputs()
+		if drainErr != nil {
+			log.Printf("%s drain tool inputs: %v", colorize("[ERROR]", ansiRed), drainErr)
+		}
+		for _, event := range drained {
+			if event.kind == normalizedToolCall && event.toolCall != nil {
+				emitToolCall(*event.toolCall)
+			}
+		}
+		if err != nil || len(drained) > 0 {
+			log.Printf("%s stream ended without a finish event; terminating with %d recovered tool call(s)",
+				colorize("[WARN]", ansiYellow), len(drained))
+		}
+		finishStream(reason, normalizer.FinalUsageInfo(), normalizer.truncated)
+	}
+
 	promptTokens, completionTokens, cacheRead, cacheWrite := normalizer.Usage()
 	usage.Record(promptTokens, completionTokens, cacheRead, cacheWrite)
 }
@@ -269,10 +303,31 @@ func handleNonStream(w http.ResponseWriter, resp *http.Response, model string, u
 		return nil
 	})
 
+	// Recover anything the upstream buffered but never terminated, exactly as
+	// the streaming path does.
+	if !normalizer.finished {
+		drained, drainErr := normalizer.drainToolInputs()
+		if drainErr != nil {
+			log.Printf("%s drain tool inputs: %v", colorize("[ERROR]", ansiRed), drainErr)
+		}
+		for _, event := range drained {
+			if event.kind == normalizedToolCall && event.toolCall != nil {
+				toolCalls.Add(*event.toolCall)
+			}
+		}
+		truncated = truncated || normalizer.truncated
+	}
+
 	if err != nil {
 		log.Printf("%s non-stream parse: %v", colorize("[ERROR]", ansiRed), err)
-		writeError(w, 502, "server_error", "upstream stream error")
-		return
+		// Discarding a partial turn wholesale loses tool calls the upstream
+		// already delivered in full. Return what arrived and mark it truncated;
+		// only a turn with nothing at all in it is a failed request.
+		if len(toolCalls.kept) == 0 && textContent.Len() == 0 {
+			writeError(w, 502, "server_error", "upstream stream error")
+			return
+		}
+		truncated = true
 	}
 
 	// Extract text content and parse embedded tool calls

--- a/internal/app/handler.go
+++ b/internal/app/handler.go
@@ -94,7 +94,8 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 	w.Header().Set("Connection", "keep-alive")
 
 	firstText := true
-	var done bool
+	var done bool     // [DONE] has been written; nothing more may be emitted
+	var finishing bool // finishStream is running its final flush
 
 	normalizer := newCCEventNormalizer()
 	textParser := NewToolCallParser()
@@ -104,7 +105,10 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 	toolCallIndex := 0
 
 	emitContent := func(content string, reasoning bool) {
-		if content == "" {
+		if content == "" || done {
+			// Once [DONE] is written the stream is closed; anything more would
+			// land after it where no OpenAI client will read it. The final flush
+			// runs with finishing=true but done=false, so it is still allowed.
 			return
 		}
 		delta := StreamDelta{}
@@ -129,6 +133,14 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 	}
 
 	emitToolCall := func(tc ToolCall) {
+		if done {
+			// A stray event after [DONE] must not be written past it, where no
+			// OpenAI client could read it. The final flush (finishing=true,
+			// done=false) is still permitted.
+			log.Printf("%s tool call %q arrived after the stream was terminated; dropping it",
+				colorize("[WARN]", ansiYellow), tc.ID)
+			return
+		}
 		if !emittedToolCalls.Add(tc) {
 			return
 		}
@@ -168,10 +180,10 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 	// loop returns, so a stream the upstream abandons mid-tool-call still
 	// delivers that call and still terminates in a shape OpenAI clients accept.
 	finishStream := func(reason string, usageInfo Usage, truncated bool) {
-		if done {
+		if done || finishing {
 			return
 		}
-		done = true
+		finishing = true
 		flushParser(reasoningParser, true)
 		flushParser(textParser, false)
 
@@ -188,6 +200,7 @@ func handleStream(w http.ResponseWriter, resp *http.Response, model string, usag
 			Usage: &usageInfo,
 		})
 		fmt.Fprintf(w, "data: [DONE]\n\n")
+		done = true
 		if debugMode {
 			log.Printf("%s %s", colorize("[DEBUG]", ansiDim), colorize(">> [DONE]", ansiGreen))
 		}

--- a/internal/app/handler.go
+++ b/internal/app/handler.go
@@ -331,19 +331,10 @@ func handleNonStream(w http.ResponseWriter, resp *http.Response, model string, u
 		truncated = truncated || normalizer.truncated
 	}
 
-	if err != nil {
-		log.Printf("%s non-stream parse: %v", colorize("[ERROR]", ansiRed), err)
-		// Discarding a partial turn wholesale loses tool calls the upstream
-		// already delivered in full. Return what arrived and mark it truncated;
-		// only a turn with nothing at all in it is a failed request.
-		if len(toolCalls.kept) == 0 && textContent.Len() == 0 {
-			writeError(w, 502, "server_error", "upstream stream error")
-			return
-		}
-		truncated = true
-	}
-
-	// Extract text content and parse embedded tool calls
+	// Extract text content and parse embedded tool calls. This must run before
+	// the error check below: a call the model wrote as text inside its reasoning
+	// only becomes visible here, and discarding the turn before parsing it would
+	// lose it.
 	visibleText := textContent.String()
 	if visibleText != "" {
 		tcp := NewToolCallParser()
@@ -367,6 +358,19 @@ func handleNonStream(w http.ResponseWriter, resp *http.Response, model string, u
 			}
 			reasoningText = strippedReasoning
 		}
+	}
+
+	if err != nil {
+		log.Printf("%s non-stream parse: %v", colorize("[ERROR]", ansiRed), err)
+		// Discarding a partial turn wholesale loses tool calls the upstream
+		// already delivered in full — including ones embedded in reasoning.
+		// Return what survived and mark it truncated; only a turn with nothing
+		// at all in it is a failed request.
+		if len(toolCalls.kept) == 0 && strings.TrimSpace(visibleText) == "" && strings.TrimSpace(reasoningText) == "" {
+			writeError(w, 502, "server_error", "upstream stream error")
+			return
+		}
+		truncated = true
 	}
 
 	msg.Content = TextContent(visibleText)

--- a/internal/app/handler_test.go
+++ b/internal/app/handler_test.go
@@ -336,7 +336,10 @@ func TestHandleStreamEmitsDoneOnFinishOnly(t *testing.T) {
 	}
 }
 
-func TestHandleStreamNoDoneOnFinishStepOnly(t *testing.T) {
+// An upstream that stops after finish-step, without ever sending finish, still
+// has to leave the client with a terminated stream. Emitting no [DONE] leaves
+// OpenAI clients waiting on a response that will never arrive.
+func TestHandleStreamTerminatesWhenFinishNeverArrives(t *testing.T) {
 	resp := &http.Response{
 		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
 			`data: {"type":"text-delta","text":"partial"}`,
@@ -349,8 +352,40 @@ func TestHandleStreamNoDoneOnFinishStepOnly(t *testing.T) {
 	handleStream(rec, resp, "test-model", &UsageTracker{}, &Config{})
 
 	body := rec.Body.String()
-	if n := strings.Count(body, "data: [DONE]"); n != 0 {
-		t.Fatalf("got %d `data: [DONE]` markers, want 0 (no finish event). body = %s", n, body)
+	if n := strings.Count(body, "data: [DONE]"); n != 1 {
+		t.Fatalf("got %d `data: [DONE]` markers, want 1. body = %s", n, body)
+	}
+	if !strings.Contains(body, `"content":"partial"`) {
+		t.Errorf("buffered content was dropped. body = %s", body)
+	}
+	if !strings.Contains(body, `"finish_reason":"stop"`) {
+		t.Errorf("no terminating finish_reason. body = %s", body)
+	}
+}
+
+// The same abort, but with a tool call still buffered: it must be recovered
+// rather than dropped, and the stream must still terminate.
+func TestHandleStreamRecoversToolCallWhenUpstreamAborts(t *testing.T) {
+	resp := &http.Response{
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`data: {"type":"tool-input-start","id":"c1","toolName":"bash"}`,
+			`data: {"type":"tool-input-delta","id":"c1","delta":"{\"command\":\"ls -la\"}"}`,
+			``, // upstream drops the connection here: no tool-input-end, no finish
+		}, "\n\n"))),
+	}
+	rec := httptest.NewRecorder()
+
+	handleStream(rec, resp, "test-model", &UsageTracker{}, &Config{})
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"name":"bash"`) || !strings.Contains(body, `ls -la`) {
+		t.Fatalf("aborted stream lost the buffered tool call. body = %s", body)
+	}
+	if n := strings.Count(body, "data: [DONE]"); n != 1 {
+		t.Fatalf("got %d `data: [DONE]` markers, want 1. body = %s", n, body)
+	}
+	if !strings.Contains(body, `"finish_reason":"tool_calls"`) {
+		t.Errorf("recovered call did not produce finish_reason tool_calls. body = %s", body)
 	}
 }
 

--- a/internal/app/precision_test.go
+++ b/internal/app/precision_test.go
@@ -1,0 +1,138 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The repair path must not round-trip numbers through float64: a 19-digit id
+// like a Discord snowflake would be silently rounded and the call would act on
+// the wrong resource.
+func TestRepairPreservesLargeInteger(t *testing.T) {
+	// truncated JSON forces the repair path
+	got := repairOrFallbackToolInput(`{"channel_id":12345678901234567890,"content":"hi"`, "discord_send")
+	if !strings.Contains(got, "12345678901234567890") {
+		t.Fatalf("large integer corrupted by repair: %s", got)
+	}
+}
+
+// A complete object whose only defect is a bare newline in a string also goes
+// through repair, and must not corrupt an untouched large id.
+func TestNewlineTriggeredRepairKeepsIDs(t *testing.T) {
+	n := newCCEventNormalizer()
+	n.Consume(CCStreamEvent{Type: "tool-input-start", ID: "c1", ToolName: "commit"})
+	n.Consume(CCStreamEvent{Type: "tool-input-delta", ID: "c1",
+		Delta: "{\"repo_id\":12345678901234567890,\"body\":\"line1\nline2\"}"})
+	evs, _ := n.Consume(CCStreamEvent{Type: "tool-input-end", ID: "c1"})
+	fin, _ := n.Consume(CCStreamEvent{Type: "finish", FinishReason: "tool-calls"})
+
+	var args string
+	for _, e := range append(evs, fin...) {
+		if e.kind == normalizedToolCall {
+			args = e.toolCall.Function.Arguments
+		}
+	}
+	if !strings.Contains(args, "12345678901234567890") {
+		t.Fatalf("repo_id corrupted: %s", args)
+	}
+}
+
+// Assistant tool_calls replayed into history must keep integer precision and
+// must not be HTML-escaped: the model reads this text back.
+func TestHistoryToolCallsPreserveNumbersAndAngles(t *testing.T) {
+	msg := Message{Role: "assistant", ToolCalls: []ToolCall{{
+		ID: "call_1", Type: "function",
+		Function: CallFunc{Name: "send", Arguments: `{"channel_id":12345678901234567890,"q":"a < b && c"}`},
+	}}}
+	parts, err := contentToCC(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var text string
+	for _, p := range parts {
+		text += p.Text
+	}
+	if !strings.Contains(text, "12345678901234567890") {
+		t.Errorf("history integer corrupted: %s", text)
+	}
+	// The old marshal round-trip HTML-escaped < and & into \\u003c / \\u0026 in
+	// the very text the model reads back. Verbatim pass-through keeps them literal,
+	// so the escaped sequences must be absent and the literal text present.
+	if strings.Contains(text, "\\u003c") || strings.Contains(text, "\\u0026") {
+		t.Errorf("history HTML-escaped, the model will read mangled text: %s", text)
+	}
+	if !strings.Contains(text, "a < b && c") {
+		t.Errorf("history angle/amp text not preserved verbatim: %s", text)
+	}
+}
+
+// Empty content tool_calls render as "arguments: {}" not "arguments: null".
+func TestEmptyArgumentsRenderAsObject(t *testing.T) {
+	msg := Message{Role: "assistant", ToolCalls: []ToolCall{{
+		ID: "c1", Type: "function", Function: CallFunc{Name: "now", Arguments: ""},
+	}}}
+	parts, _ := contentToCC(msg)
+	if !strings.Contains(parts[0].Text, "arguments: {}") {
+		t.Fatalf("empty arguments rendered wrong: %s", parts[0].Text)
+	}
+}
+
+// A no-argument tool must carry an empty-object schema, not omit it.
+func TestNoArgToolGetsEmptySchema(t *testing.T) {
+	out := toolsToCC([]Tool{{Type: "function", Function: ToolFunction{Name: "get_time"}}})
+	if out[0].InputSchema == nil {
+		t.Fatalf("no-arg tool lost its input_schema entirely")
+	}
+	if out[0].InputSchema["type"] != "object" {
+		t.Fatalf("no-arg tool schema = %v, want an empty object schema", out[0].InputSchema)
+	}
+}
+
+// A mid-stream error must not discard a tool call the model embedded in its
+// reasoning; the non-stream path parses reasoning before deciding to 502.
+func TestNonStreamKeepsReasoningCallOnError(t *testing.T) {
+	dsml := "<｜｜DSML｜｜tool_calls><invoke name=\"bash\">" +
+		"<parameter name=\"command\" string=\"true\">rm -rf /tmp/x</parameter></invoke></｜｜DSML｜｜tool_calls>"
+	reasoning, _ := json.Marshal(dsml)
+	body := strings.Join([]string{
+		`data: {"type":"reasoning-delta","delta":` + string(reasoning) + `}`,
+		`data: {oops bad frame}`,
+	}, "\n\n")
+	rec := httptest.NewRecorder()
+	handleNonStream(rec, &http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		"m", &UsageTracker{}, &Config{})
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (a reasoning-embedded call survived)", rec.Code)
+	}
+	var out ChatResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Choices[0].Message.ToolCalls) != 1 {
+		t.Fatalf("reasoning-embedded call lost: %+v", out.Choices[0].Message.ToolCalls)
+	}
+}
+
+// An empty data: keep-alive line must not abort the stream.
+func TestEmptyDataLineIsKeepalive(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"type":"tool-input-start","id":"c1","toolName":"bash"}`,
+		`data:`,
+		`data: {"type":"tool-call","toolCallId":"c1","toolName":"bash","input":{"command":"ls"}}`,
+		`data: {"type":"finish","finishReason":"tool-calls"}`,
+	}, "\n\n")
+	var kinds []string
+	err := ParseStreamEvents(&http.Response{Body: io.NopCloser(strings.NewReader(body))},
+		func(ev CCStreamEvent) error { kinds = append(kinds, ev.Type); return nil })
+	if err != nil {
+		t.Fatalf("empty data line aborted the stream: %v (events=%v)", err, kinds)
+	}
+	if strings.Join(kinds, ",") != "tool-input-start,tool-call,finish" {
+		t.Fatalf("events lost around empty data line: %v", kinds)
+	}
+}

--- a/internal/app/toolcallloss_test.go
+++ b/internal/app/toolcallloss_test.go
@@ -1,0 +1,195 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A stream that ends while a tool input is still buffered must still deliver
+// the call. Upstream does not always send tool-input-end before finish.
+func TestFinishDrainsBufferedToolInput(t *testing.T) {
+	n := newCCEventNormalizer()
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: "c1", ToolName: "bash"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: "c1", Delta: `{"command":"ls -la"}`})
+
+	events := mustConsume(t, n, CCStreamEvent{Type: "finish", FinishReason: "tool-calls"})
+
+	call := onlyToolCall(t, events)
+	if call.ID != "c1" || call.Function.Name != "bash" {
+		t.Fatalf("recovered wrong call: %+v", call)
+	}
+	if call.Function.Arguments != `{"command":"ls -la"}` {
+		t.Fatalf("arguments mangled: %s", call.Function.Arguments)
+	}
+	if last := events[len(events)-1]; last.kind != normalizedFinish {
+		t.Fatalf("finish must remain the last event, got kind %v", last.kind)
+	}
+}
+
+// Buffered inputs drain in the order the model produced them, not in Go map order.
+func TestFinishDrainsInArrivalOrder(t *testing.T) {
+	n := newCCEventNormalizer()
+	for _, id := range []string{"a", "b", "c", "d", "e", "f", "g", "h"} {
+		mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: id, ToolName: "bash"})
+		mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: id, Delta: `{"command":"` + id + `"}`})
+	}
+
+	events := mustConsume(t, n, CCStreamEvent{Type: "finish", FinishReason: "tool-calls"})
+
+	var got []string
+	for _, ev := range events {
+		if ev.kind == normalizedToolCall {
+			got = append(got, ev.toolCall.ID)
+		}
+	}
+	if strings.Join(got, "") != "abcdefgh" {
+		t.Fatalf("drain order = %v, want a..h", got)
+	}
+}
+
+// tool-error can arrive in place of tool-input-end; it must not discard the call.
+func TestToolErrorTerminatesToolInput(t *testing.T) {
+	n := newCCEventNormalizer()
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: "c2", ToolName: "write"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: "c2", Delta: `{"path":"/a","content":"x"}`})
+
+	events := mustConsume(t, n, CCStreamEvent{Type: "tool-error", ToolCallID: "c2", ToolName: "write"})
+
+	call := onlyToolCall(t, events)
+	if call.ID != "c2" || call.Function.Arguments != `{"path":"/a","content":"x"}` {
+		t.Fatalf("tool-error lost the call: %+v", call)
+	}
+}
+
+// The observed production ordering is tool-input-end, tool-call, tool-error for
+// the same id. Only one call may reach the client.
+func TestToolErrorAfterEndDoesNotDuplicate(t *testing.T) {
+	n := newCCEventNormalizer()
+	var deduper toolCallDeduper
+
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: "c3", ToolName: "bash"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: "c3", Delta: `{"command":"echo hi"}`})
+	for _, ev := range []CCStreamEvent{
+		{Type: "tool-input-end", ID: "c3"},
+		{Type: "tool-call", ToolCallID: "c3", ToolName: "bash", Input: map[string]any{"command": "echo hi"}},
+		{Type: "tool-error", ToolCallID: "c3", ToolName: "bash", Input: `{"command":"echo hi"}`},
+	} {
+		for _, out := range mustConsume(t, n, ev) {
+			if out.kind == normalizedToolCall {
+				deduper.Add(*out.toolCall)
+			}
+		}
+	}
+
+	if len(deduper.kept) != 1 {
+		t.Fatalf("expected 1 call after dedup, got %d: %+v", len(deduper.kept), deduper.kept)
+	}
+}
+
+// An upstream cut off by the output-token cap leaves truncated arguments that
+// repairOrFallbackToolInput patches into valid JSON. The client must be told
+// "length", never "tool_calls".
+func TestTruncatedToolInputReportsLength(t *testing.T) {
+	n := newCCEventNormalizer()
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-start", ID: "c4", ToolName: "write"})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-delta", ID: "c4", Delta: `{"path":"/a.py","content":"line1`})
+	mustConsume(t, n, CCStreamEvent{Type: "tool-input-end", ID: "c4"})
+
+	events := mustConsume(t, n, CCStreamEvent{Type: "finish", FinishReason: "stop"})
+	finish := events[len(events)-1]
+	if !finish.truncated {
+		t.Fatal("normalizer did not flag the repaired input as truncated")
+	}
+	if got := resolveFinishReason(finish.finishReason, true, finish.truncated); got != "length" {
+		t.Fatalf("finish_reason = %q, want \"length\"", got)
+	}
+}
+
+func TestResolveFinishReason(t *testing.T) {
+	cases := []struct {
+		upstream            string
+		hasToolCalls, trunc bool
+		want                string
+	}{
+		{"tool_calls", true, false, "tool_calls"},
+		{"stop", true, false, "tool_calls"},
+		{"stop", false, false, "stop"},
+		{"length", true, false, "length"},  // upstream hit the cap mid-call
+		{"stop", true, true, "length"},     // arguments needed repair
+		{"length", false, false, "length"}, // plain text truncation
+	}
+	for _, c := range cases {
+		if got := resolveFinishReason(c.upstream, c.hasToolCalls, c.trunc); got != c.want {
+			t.Errorf("resolveFinishReason(%q,%v,%v) = %q, want %q",
+				c.upstream, c.hasToolCalls, c.trunc, got, c.want)
+		}
+	}
+}
+
+// A text-form tool call larger than the old 128 KB cap must still be recovered.
+func TestLargeTextToolCallSurvivesBuffering(t *testing.T) {
+	body := strings.Repeat("x", 400*1024)
+	p := NewToolCallParser()
+
+	content, calls := p.Feed(`prose before. Assistant requested tool write (call_x) with arguments: {"path":"/a","content":"`+body, false)
+	if len(calls) != 0 {
+		t.Fatalf("emitted a call before its JSON completed: %+v", calls)
+	}
+	if content != "prose before. " {
+		t.Fatalf("leading prose = %q, want %q", content, "prose before. ")
+	}
+
+	content, calls = p.Feed(`"}`, true)
+	if len(calls) != 1 {
+		t.Fatalf("large tool call was lost: %d calls, %d bytes flushed as text", len(calls), len(content))
+	}
+	var args struct{ Content string }
+	if err := json.Unmarshal([]byte(calls[0].Function.Arguments), &args); err != nil {
+		t.Fatalf("arguments not valid JSON: %v", err)
+	}
+	if len(args.Content) != len(body) {
+		t.Fatalf("content truncated: got %d bytes, want %d", len(args.Content), len(body))
+	}
+}
+
+// Text preceding an oversized unterminated call must not be held hostage by it,
+// and the buffer must not grow past the cap.
+func TestOversizedUnterminatedCallDegradesToText(t *testing.T) {
+	p := NewToolCallParser()
+	p.maxSize = 4096
+
+	content, calls := p.Feed("visible prose. "+`Assistant requested tool write (c) with arguments: {"content":"`+strings.Repeat("y", 8192), false)
+	if len(calls) != 0 {
+		t.Fatalf("unexpected calls: %+v", calls)
+	}
+	if !strings.HasPrefix(content, "visible prose. ") {
+		t.Fatalf("preceding prose was withheld; content starts %q", content[:min(40, len(content))])
+	}
+	if p.buf.Len() > p.maxSize {
+		t.Fatalf("buffer grew past the cap: %d > %d", p.buf.Len(), p.maxSize)
+	}
+}
+
+func mustConsume(t *testing.T, n *ccEventNormalizer, ev CCStreamEvent) []normalizedCCEvent {
+	t.Helper()
+	events, err := n.Consume(ev)
+	if err != nil {
+		t.Fatalf("consume %s: %v", ev.Type, err)
+	}
+	return events
+}
+
+func onlyToolCall(t *testing.T, events []normalizedCCEvent) ToolCall {
+	t.Helper()
+	var found []ToolCall
+	for _, ev := range events {
+		if ev.kind == normalizedToolCall && ev.toolCall != nil {
+			found = append(found, *ev.toolCall)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly 1 tool call, got %d", len(found))
+	}
+	return found[0]
+}

--- a/internal/app/toolparse.go
+++ b/internal/app/toolparse.go
@@ -89,25 +89,68 @@ func NewToolCallParser() *ToolCallParser {
 func (p *ToolCallParser) Feed(chunk string, done bool) (content string, calls []ToolCall) {
 	p.buf.WriteString(chunk)
 
-	raw := p.buf.String()
-	originalRaw := raw
-
 	// Native DSML can contain multiple invokes and can be fragmented across
-	// text deltas. Remove only complete, valid envelopes; retain an incomplete
-	// suffix for the next Feed call.
-	var pendingDSML string
-	var dsmlValid bool
-	var recoveredDSMLIDs map[string]bool
-	raw, pendingDSML, dsmlValid, recoveredDSMLIDs = rewriteRawDSMLToolCalls(raw, done)
-	if !dsmlValid {
-		p.buf.Reset()
-		return originalRaw, nil
+	// text deltas. Rewrite complete envelopes into the legacy textual form the
+	// scan handles, keep an incomplete suffix buffered, and mark a malformed
+	// envelope as literal text.
+	segments, pendingDSML, recoveredDSMLIDs := rewriteRawDSMLToolCalls(p.buf.String(), done)
+
+	var contentBuf strings.Builder
+	var remaining string
+	preserveRemaining := false
+
+	for _, segment := range segments {
+		if segment.literal {
+			// A rejected envelope. Its bytes reach the client verbatim but are
+			// never scanned: text inside an envelope the parser refused must not
+			// become an executable tool call.
+			contentBuf.WriteString(segment.text)
+			continue
+		}
+		content, segCalls, tail, preserve := scanLegacyToolCalls(segment.text, done, recoveredDSMLIDs)
+		contentBuf.WriteString(content)
+		calls = append(calls, segCalls...)
+		remaining = tail
+		preserveRemaining = preserve
 	}
 
-	// ----- scan buffer for tool-call lines -------------------------------
+	// ----- preserve unprocessed tail in buffer ---------------------------
+	//
+	// Everything the scan resolved has already gone to contentBuf or calls, so
+	// only genuinely unresolved text is carried forward. The size cap therefore
+	// applies to that carry alone: text preceding an in-flight tool call is
+	// never held hostage by it, and a call larger than the cap degrades to prose
+	// instead of growing the buffer without bound.
+	if done {
+		contentBuf.WriteString(remaining)
+		p.buf.Reset()
+	} else if preserveRemaining || pendingDSML != "" {
+		var carry strings.Builder
+		if preserveRemaining {
+			carry.WriteString(remaining)
+		}
+		carry.WriteString(pendingDSML)
+		p.buf.Reset()
+		if carry.Len() > p.maxSize {
+			contentBuf.WriteString(carry.String())
+		} else {
+			p.buf.WriteString(carry.String())
+		}
+	} else {
+		p.buf.Reset()
+	}
+
+	return contentBuf.String(), calls
+}
+
+// scanLegacyToolCalls extracts textual "Assistant requested tool ..." calls from
+// one scannable segment.
+//
+// It returns the ordinary text, the recovered calls, any trailing text that is
+// still an incomplete call, and whether that tail must stay buffered.
+func scanLegacyToolCalls(raw string, done bool, recoveredDSMLIDs map[string]bool) (content string, calls []ToolCall, remaining string, preserveRemaining bool) {
 	var contentBuf strings.Builder
 	pos := 0
-	preserveRemaining := false
 
 	for pos < len(raw) {
 		rest := raw[pos:]
@@ -214,34 +257,7 @@ func (p *ToolCallParser) Feed(chunk string, done bool) (content string, calls []
 		pos = jsonEnd
 	}
 
-	// ----- preserve unprocessed tail in buffer ---------------------------
-	//
-	// Everything the scan resolved has already gone to contentBuf or calls, so
-	// only genuinely unresolved text is carried forward. The size cap therefore
-	// applies to that carry alone: text preceding an in-flight tool call is
-	// never held hostage by it, and a call larger than the cap degrades to prose
-	// instead of growing the buffer without bound.
-	remaining := raw[pos:]
-	if done {
-		contentBuf.WriteString(remaining)
-		p.buf.Reset()
-	} else if preserveRemaining || pendingDSML != "" {
-		var carry strings.Builder
-		if preserveRemaining {
-			carry.WriteString(remaining)
-		}
-		carry.WriteString(pendingDSML)
-		p.buf.Reset()
-		if carry.Len() > p.maxSize {
-			contentBuf.WriteString(carry.String())
-		} else {
-			p.buf.WriteString(carry.String())
-		}
-	} else {
-		p.buf.Reset()
-	}
-
-	return contentBuf.String(), calls
+	return contentBuf.String(), calls, raw[pos:], preserveRemaining
 }
 
 // ---------------------------------------------------------------------------
@@ -370,12 +386,22 @@ func (parameter *rawDSMLParameter) UnmarshalXML(decoder *xml.Decoder, start xml.
 
 // rewriteRawDSMLToolCalls replaces complete valid native DSML envelopes with
 // the legacy textual form already handled by Feed. This preserves source order
-// when a response mixes native DSML and legacy textual calls. Malformed or
-// incomplete envelopes remain visible text; an incomplete envelope is buffered
-// while the stream is still open.
-func rewriteRawDSMLToolCalls(raw string, done bool) (content string, pending string, valid bool, recoveredIDs map[string]bool) {
-	var out strings.Builder
+// when a response mixes native DSML and legacy textual calls.
+//
+// A malformed envelope is passed through as visible text and scanning
+// continues. Failing the whole buffer instead would discard every other call it
+// holds, including complete legacy ones that parse fine.
+func rewriteRawDSMLToolCalls(raw string, done bool) (segments []textSegment, pending string, recoveredIDs map[string]bool) {
 	recoveredIDs = make(map[string]bool)
+	var scannable strings.Builder
+
+	flush := func() {
+		if scannable.Len() > 0 {
+			segments = append(segments, textSegment{text: scannable.String()})
+			scannable.Reset()
+		}
+	}
+
 	pos := 0
 	for pos < len(raw) {
 		open := findRawDSMLOpenOutsideLegacyCall(raw, pos)
@@ -383,39 +409,94 @@ func rewriteRawDSMLToolCalls(raw string, done bool) (content string, pending str
 			rest := raw[pos:]
 			if !done {
 				if partial := partialRawDSMLStart(rest); partial >= 0 {
-					out.WriteString(rest[:partial])
-					return out.String(), rest[partial:], true, recoveredIDs
+					scannable.WriteString(rest[:partial])
+					flush()
+					return segments, rest[partial:], recoveredIDs
 				}
 			}
-			out.WriteString(rest)
+			scannable.WriteString(rest)
 			break
 		}
 
 		envelopeStart := open[0]
 		bodyStart := open[1]
-		out.WriteString(raw[pos:envelopeStart])
+		scannable.WriteString(raw[pos:envelopeStart])
 		close := rawDSMLCloseRe.FindStringIndex(raw[bodyStart:])
 		if close == nil {
 			if !done {
-				return out.String(), raw[envelopeStart:], true, recoveredIDs
+				flush()
+				return segments, raw[envelopeStart:], recoveredIDs
 			}
-			return out.String() + raw[envelopeStart:], "", false, nil
+			// Unterminated at end of stream: surface it as literal text.
+			flush()
+			segments = append(segments, textSegment{text: raw[envelopeStart:], literal: true})
+			return segments, "", recoveredIDs
 		}
 
 		closeStart := bodyStart + close[0]
 		closeEnd := bodyStart + close[1]
 		parsed, ok := parseRawDSMLInvokes(raw[bodyStart:closeStart])
 		if !ok {
-			return out.String() + raw[envelopeStart:], "", false, nil
+			flush()
+			segments = append(segments, textSegment{text: raw[envelopeStart:closeEnd], literal: true})
+			pos = closeEnd
+			continue
 		}
 		for _, call := range parsed {
 			recoveredIDs[call.ID] = true
-			fmt.Fprintf(&out, "Assistant requested tool %s (%s) with arguments: %s",
+			fmt.Fprintf(&scannable, "Assistant requested tool %s (%s) with arguments: %s",
 				call.Function.Name, call.ID, call.Function.Arguments)
 		}
 		pos = closeEnd
 	}
-	return out.String(), "", true, recoveredIDs
+	flush()
+	return segments, "", recoveredIDs
+}
+
+// textSegment is a run of the buffer with one disposition. A literal segment is
+// forwarded to the client verbatim and never scanned for tool calls; a
+// scannable one goes through the legacy textual scan.
+type textSegment struct {
+	text    string
+	literal bool
+}
+
+// dsmlTagStartRe matches the only element names a DSML envelope may contain.
+var dsmlTagStartRe = regexp.MustCompile(`^</?(invoke|parameter)[\s>/]`)
+
+// xmlEntityRe matches an entity reference that is already well-formed.
+var xmlEntityRe = regexp.MustCompile(`^&(amp|lt|gt|quot|apos|#[0-9]+|#x[0-9a-fA-F]+);`)
+
+// escapeRawDSMLBody makes model-authored text parseable as XML.
+//
+// Tool arguments are raw text, not escaped markup: a bash command containing
+// `&&`, or any code containing `<`, is not well-formed XML, and encoding/xml
+// rejects the entire envelope over it. Since those characters are near-certain
+// in bash, write, and edit arguments, an unescaped body means the call cannot be
+// recovered at all. Escape everything that is not a DSML tag or an existing
+// entity, so only the envelope's own structure reaches the parser as markup.
+func escapeRawDSMLBody(body string) string {
+	var b strings.Builder
+	b.Grow(len(body) + 16)
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '<':
+			if dsmlTagStartRe.MatchString(body[i:]) {
+				b.WriteByte('<')
+			} else {
+				b.WriteString("&lt;")
+			}
+		case '&':
+			if xmlEntityRe.MatchString(body[i:]) {
+				b.WriteByte('&')
+			} else {
+				b.WriteString("&amp;")
+			}
+		default:
+			b.WriteByte(body[i])
+		}
+	}
+	return b.String()
 }
 
 // findRawDSMLOpenOutsideLegacyCall ignores marker-like text inside the JSON
@@ -452,15 +533,11 @@ func findRawDSMLOpenOutsideLegacyCall(raw string, start int) []int {
 }
 
 func parseRawDSMLInvokes(body string) ([]ToolCall, bool) {
-	// encoding/xml normalizes CDATA into CharData. Reject all declaration-like
-	// syntax lexically so comments, CDATA, directives, and processing
-	// instructions cannot bypass the strict token grammar below.
-	if strings.Contains(body, "<!") || strings.Contains(body, "<?") {
-		return nil, false
-	}
-
 	var document rawDSMLDocument
-	wrapped := "<tool_calls>" + body + "</tool_calls>"
+	// escapeRawDSMLBody leaves only invoke/parameter tags as markup, so
+	// declaration-like syntax (comments, CDATA, directives, processing
+	// instructions) is already neutralised into character data.
+	wrapped := "<tool_calls>" + escapeRawDSMLBody(body) + "</tool_calls>"
 	if err := xml.Unmarshal([]byte(wrapped), &document); err != nil || len(document.Invokes) == 0 ||
 		strings.TrimSpace(document.Text) != "" {
 		return nil, false
@@ -830,12 +907,16 @@ func scanString(s string, start int) (end int, complete bool) {
 }
 
 // scanLiteral consumes a JSON literal (null / true / false).
+//
+// A literal that runs to the end of the buffer may still be growing, so it is
+// only complete once a delimiter proves it ended. Reporting a boundary-truncated
+// token as complete would emit "t" or "12" as the model's arguments.
 func scanLiteral(s string, start int) (end int, complete bool) {
 	i := start
 	for i < len(s) && isJSONIdent(rune(s[i])) {
 		i++
 	}
-	return i, true // literals are always "complete" at the current boundary
+	return i, i < len(s)
 }
 
 // scanNumber consumes a JSON number token (including negative, decimal, and
@@ -868,7 +949,9 @@ func scanNumber(s string, start int) (end int, complete bool) {
 			i++
 		}
 	}
-	return i, true
+	// Same boundary rule as scanLiteral: a number touching the end of the buffer
+	// may still be gaining digits.
+	return i, i < len(s)
 }
 
 func isJSONIdent(r rune) bool {

--- a/internal/app/toolparse.go
+++ b/internal/app/toolparse.go
@@ -57,7 +57,13 @@ var rawDSMLOpenRe = regexp.MustCompile(regexp.QuoteMeta(rawDSMLCanonicalOpen))
 var rawDSMLCloseRe = regexp.MustCompile(regexp.QuoteMeta(rawDSMLCanonicalClose))
 var rawDSMLToolNameRe = regexp.MustCompile(`^[^\s()]+$`)
 
-const defaultMaxBuf = 128 * 1024 // 128 KB
+// defaultMaxBuf bounds how much *unresolved* text the parser holds — text that
+// may still turn out to be part of a tool call. It must exceed the largest tool
+// call a single response can contain, otherwise a big write is flushed as prose
+// and the call is lost. maximumCCMaxTokens caps a response at 200k tokens,
+// roughly 800 KB of text, so 2 MB clears the worst case with room to spare
+// while keeping the per-chunk rescan bounded.
+const defaultMaxBuf = 2 * 1024 * 1024 // 2 MB
 
 // ToolCallParser buffers incoming text chunks, scanning for embedded
 // tool-call lines.  Non-tool text is returned as ordinary content;
@@ -85,12 +91,6 @@ func (p *ToolCallParser) Feed(chunk string, done bool) (content string, calls []
 
 	raw := p.buf.String()
 	originalRaw := raw
-
-	// ----- overflow protection -------------------------------------------
-	if len(raw) > p.maxSize {
-		p.buf.Reset()
-		return raw, nil
-	}
 
 	// Native DSML can contain multiple invokes and can be fragmented across
 	// text deltas. Remove only complete, valid envelopes; retain an incomplete
@@ -215,16 +215,28 @@ func (p *ToolCallParser) Feed(chunk string, done bool) (content string, calls []
 	}
 
 	// ----- preserve unprocessed tail in buffer ---------------------------
+	//
+	// Everything the scan resolved has already gone to contentBuf or calls, so
+	// only genuinely unresolved text is carried forward. The size cap therefore
+	// applies to that carry alone: text preceding an in-flight tool call is
+	// never held hostage by it, and a call larger than the cap degrades to prose
+	// instead of growing the buffer without bound.
 	remaining := raw[pos:]
 	if done {
 		contentBuf.WriteString(remaining)
 		p.buf.Reset()
 	} else if preserveRemaining || pendingDSML != "" {
-		p.buf.Reset()
+		var carry strings.Builder
 		if preserveRemaining {
-			p.buf.WriteString(remaining)
+			carry.WriteString(remaining)
 		}
-		p.buf.WriteString(pendingDSML)
+		carry.WriteString(pendingDSML)
+		p.buf.Reset()
+		if carry.Len() > p.maxSize {
+			contentBuf.WriteString(carry.String())
+		} else {
+			p.buf.WriteString(carry.String())
+		}
 	} else {
 		p.buf.Reset()
 	}

--- a/internal/app/toolparse.go
+++ b/internal/app/toolparse.go
@@ -99,7 +99,8 @@ func (p *ToolCallParser) Feed(chunk string, done bool) (content string, calls []
 	var remaining string
 	preserveRemaining := false
 
-	for _, segment := range segments {
+	for i, segment := range segments {
+		last := i == len(segments)-1
 		if segment.literal {
 			// A rejected envelope. Its bytes reach the client verbatim but are
 			// never scanned: text inside an envelope the parser refused must not
@@ -110,8 +111,16 @@ func (p *ToolCallParser) Feed(chunk string, done bool) (content string, calls []
 		content, segCalls, tail, preserve := scanLegacyToolCalls(segment.text, done, recoveredDSMLIDs)
 		contentBuf.WriteString(content)
 		calls = append(calls, segCalls...)
-		remaining = tail
-		preserveRemaining = preserve
+		if last {
+			// Only the final segment's tail can still be completed by the next
+			// chunk. An earlier segment's incomplete tail is already followed by
+			// other arrived content, so it will never complete — flush it as
+			// text rather than dropping it or carrying the wrong tail forward.
+			remaining = tail
+			preserveRemaining = preserve
+		} else {
+			contentBuf.WriteString(tail)
+		}
 	}
 
 	// ----- preserve unprocessed tail in buffer ---------------------------

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -12,11 +12,28 @@ import (
 // ============================================================================
 
 type ChatRequest struct {
-	Model     string    `json:"model"`
-	Messages  []Message `json:"messages"`
-	Stream    bool      `json:"stream"`
-	MaxTokens int       `json:"max_tokens,omitempty"`
-	Tools     []Tool    `json:"tools,omitempty"`
+	Model    string    `json:"model"`
+	Messages []Message `json:"messages"`
+	Stream   bool      `json:"stream"`
+	// MaxTokens is the deprecated OpenAI field. MaxCompletionTokens is its
+	// replacement and is what current clients actually send, so both are read
+	// and MaxCompletionTokens wins. Accepting only max_tokens silently dropped
+	// the caller's budget and cut tool arguments off at the default.
+	MaxTokens           int    `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int    `json:"max_completion_tokens,omitempty"`
+	Tools               []Tool `json:"tools,omitempty"`
+}
+
+// OutputTokenBudget returns the caller's requested completion-token limit,
+// or 0 when they did not ask for one.
+func (r *ChatRequest) OutputTokenBudget() int {
+	if r.MaxCompletionTokens > 0 {
+		return r.MaxCompletionTokens
+	}
+	if r.MaxTokens > 0 {
+		return r.MaxTokens
+	}
+	return 0
 }
 
 type Message struct {

--- a/internal/app/types.go
+++ b/internal/app/types.go
@@ -153,6 +153,11 @@ type ToolCall struct {
 	// cross-representation deduplication without collapsing two intentional,
 	// semantically identical calls.
 	recoveredRawDSML bool
+
+	// repaired marks arguments that only parse because truncated JSON was
+	// patched. Such a call is a best guess and must yield to an authoritative
+	// payload for the same id.
+	repaired bool
 }
 
 type CallFunc struct {


### PR DESCRIPTION
## 背景

代理会"吞掉很多工具调用"——模型发出的工具调用要么到不了 OpenAI 客户端，要么到达时已被静默损坏。多轮排查（含独立多智能体审计 + 全分割点 fuzzing + 假上游与真实 deepseek 端到端验证）逐层定位并修复。

## 修了什么

**吞掉工具调用（call never reaches the client）**
- 流结束时排空仍在缓冲的 tool-input；`tool-error` 作为终结器而非被忽略；按到达顺序 drain（`events.go`）
- 上游不发 `finish` 就断流时，两条路径都 drain + 终结，不再让客户端永远挂着（`handler.go`）
- `ToolCallParser` 的 128KB 上限从扫描前移到扫描后，只作用于未解析尾部，上限提到 2MB；segment 重构后非最后段的尾巴不再丢失（`toolparse.go`）
- SSE reader 从 `bufio.Scanner`（1MB token 上限，超限丢弃 tool-call + finish）改到 `bufio.Reader`，无长度上限；`id:`/`retry:` 等非 data 字段行与空 `data:` keep-alive 不再打挂整条流（`cc.go`）
- DSML-as-text 里含 `&`/`<`（bash/write/edit 载荷几乎必含）不再让整个 envelope 作废；坏 envelope 不再连坐同缓冲的合法调用；被拒 envelope 内的注入文本保持不可执行（`toolparse.go`）
- 非流式在流中途报错时，先解析推理内嵌调用再决定是否 502，不再整个丢弃

**静默损坏工具参数（call arrives corrupted）**
- 截断参数被"修复"成合法 JSON 后，`finish_reason` 如实报 `length` 而非谎报 `tool_calls`
- repair 路径与历史回传改用 `json.Number` / 逐字透传，19 位整数（Discord snowflake、纳秒时间戳）不再被 float64 round-trip 改写；历史文本不再被 HTML 转义
- 权威 `tool-call` 事件取代先到的截断重建版（日志实锤：客户端曾收到 14600B 而上游有 42985B）
- `tool-error` 的 string 型 input 不再双重编码；标量参数跨 delta 不再被截断当完整
- write 兜底不再伪造 `content:""`（客户端执行会 truncate 文件）

**请求侧 / 兼容性**
- 读取 `max_completion_tokens`（生产流量 33/33 只发这个字段，旧代码只认 `max_tokens`，预算被静默降到默认值导致参数在输出上限处被截断）
- 无参工具补上空 schema，避免一个无参工具让整个请求的工具集在上游失效
- `.gitignore` 覆盖 `--debug` 写出的 `log.txt*`（含完整请求体）

## 验证

- 加了 ~40 个回归测试；每个关键修复都在修复前代码上验证过会失败
- `go test -race ./...`、`go vet ./...` 全绿
- 全分割点 fuzzing：已知正确输入在每个字节位置切分喂入，恢复结果与整段一致
- 假上游复现全部 loss/腐蚀场景；真实 deepseek-v4-pro 端到端确认并行调用、多轮回传、18 位 snowflake 逐位保留

## 仍未处理（需上游决策）

`contentToCC` 把工具历史压平成散文（`CCPart` 的结构化字段 `ToolCallID`/`ToolName`/`Input` 从未使用）。上结构化 parts 需先对线上 `/alpha/generate` 验证方言接受度（git 历史显示前两次尝试用了错方言），故留待人工拍板。

🤖 Generated with [Claude Code](https://claude.com/claude-code)