### PR TITLE
fix: send empty message content as an array instead of null

### DIFF
--- a/internal/app/cc.go
+++ b/internal/app/cc.go
@@ -612,7 +612,7 @@ func contentToCC(m Message) ([]CCPart, error) {
 		}}, nil
 	}
 
-	var parts []CCPart
+	parts := []CCPart{}
 	if m.Role == "assistant" && m.ReasoningContent != "" {
 		parts = append(parts, CCPart{Type: "reasoning", Text: m.ReasoningContent})
 	}


### PR DESCRIPTION
Messages whose content is empty (`""`, `[]`, or omitted/`null`) (for example an assistant turn that only produced tool calls, or an interrupted turn) are forwarded to Command Code with an empty content array (`[]`). Command Code rejects a `null` or omitted `content` with
`Invalid request error ... expected string, received null at "params.messages[N].content"`. Since clients resend the full history on every turn, such a message would permanently break the session until it was rebuilt; normalizing empty content to `[]` keeps the session usable.